### PR TITLE
Fix minimal test

### DIFF
--- a/.ci_support/environment_mini.yml
+++ b/.ci_support/environment_mini.yml
@@ -1,0 +1,10 @@
+channels:
+- conda-forge
+dependencies:
+- ase =3.22.1
+- coveralls
+- coverage
+- codacy-coverage
+- matplotlib-base =3.7.1
+- numpy =1.24.3
+- scipy =1.10.1

--- a/.github/workflows/mini.yml
+++ b/.github/workflows/mini.yml
@@ -19,15 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup environment
-      run: |
-        cp .ci_support/environment.yml environment.yml
-        sed -i '/aimsgb/d' environment.yml
-        sed -i '/phonopy/d' environment.yml
-        sed -i '/pymatgen/d' environment.yml
-        sed -i '/pyscal/d' environment.yml
-        sed -i '/scikit-learn/d' environment.yml
-        sed -i '/spglib/d' environment.yml
-        sed -i '/sqsgenerator/d' environment.yml
+      run: cp .ci_support/environment_mini.yml environment.yml
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
       with:


### PR DESCRIPTION
The previous issue was that the `minimal` environment was created by removing individual packages from the existing environment, this was confusing. Now both environments are clearly separated. 