### PR TITLE
Plotly aspectmode

### DIFF
--- a/structuretoolkit/visualize.py
+++ b/structuretoolkit/visualize.py
@@ -207,6 +207,7 @@ def _plot3d_plotly(
     )
     fig.update_layout(scene_camera=angle)
     fig.update_traces(marker=dict(line=dict(width=0.1, color="DarkSlateGrey")))
+    fig.update_scenes(aspectmode='data')
     return fig
 
 

--- a/structuretoolkit/visualize.py
+++ b/structuretoolkit/visualize.py
@@ -205,7 +205,7 @@ def _plot3d_plotly(
     )
     fig.update_layout(scene_camera=angle)
     fig.update_traces(marker=dict(line=dict(width=0.1, color="DarkSlateGrey")))
-    fig.update_scenes(aspectmode='data')
+    fig.update_scenes(aspectmode="data")
     return fig
 
 


### PR DESCRIPTION
I realized that there's this command `fig.update_scenes(aspectmode='data')` which plots the box in the correct aspect ratio, i.e. from this (which is wrong):

<img width="211" alt="Screenshot 2023-08-07 at 17 00 58" src="https://github.com/pyiron/structuretoolkit/assets/37879103/aee36882-1a42-4285-b83a-53c48aeb2ca8">

we go to this (which is correct):

<img width="495" alt="Screenshot 2023-08-07 at 17 01 59" src="https://github.com/pyiron/structuretoolkit/assets/37879103/d21eaca1-a95b-4741-a0e6-915c2555e40d">

