### PR TITLE
Provide a shortcut to ase.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ The `structuretoolkit` is currently under development.
 
 ```python
 import structuretoolkit as stk
-from ase.build import bulk
 
-structure = bulk("Al", cubic=True)
+structure = stk.build.ase.bulk("Al", cubic=True)
 stk.analyse.get_adaptive_cna_descriptors(structure)
 stk.plot3d(structure)
 ```
@@ -43,6 +42,7 @@ stk.plot3d(structure)
 * `stk.analyse.get_strain()`
 
 ### Build
+* `stk.build.ase` (Merely a shortcut to the `ase.build` module)
 * `stk.build.get_grainboundary_info()`
 * `stk.build.grainboundary()`
 * `stk.build.high_index_surface()`

--- a/structuretoolkit/build/__init__.py
+++ b/structuretoolkit/build/__init__.py
@@ -1,3 +1,4 @@
+from ase import build as ase  # Just a shortcut structuretoolkit.build.ase == ase.build
 from structuretoolkit.build.aimsgb import (
     grainboundary,
     get_grainboundary_info

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+
+from ase import build
+
+from structuretoolkit.build import ase
+
+
+class TestAse(unittest.TestCase):
+    def test_build_shortcut(self):
+        self.assertIs(ase, build, msg="Our link should be a simple shortcut.")


### PR DESCRIPTION
So that we can do common stk operations using a single import. Tests and readme are updated accordingly.

```python
structuretoolkit.build.ase is ase.build
>>> True
```