### PR TITLE
Create mesh

### DIFF
--- a/structuretoolkit/__init__.py
+++ b/structuretoolkit/__init__.py
@@ -37,6 +37,7 @@ from structuretoolkit.build import (
     grainboundary,
     high_index_surface,
     sqs_structures,
+    create_mesh,
 )
 
 # Common

--- a/structuretoolkit/build/__init__.py
+++ b/structuretoolkit/build/__init__.py
@@ -9,3 +9,4 @@ from structuretoolkit.build.surface import (
     high_index_surface,
     get_high_index_surface_info
 )
+from structuretoolkit.build.mesh import create_mesh

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import numpy as np
 import warnings
-from ase.atoms import Atoms
 import typing
 
 
 def create_mesh(
-    structure: Atoms,
+    structure: "ase.atoms.Atoms",
     n_mesh: typing.Union[int, list[int, int, int]] = 10,
     density: typing.Optional[float] = None,
     endpoint: bool = False
@@ -24,7 +25,7 @@ def create_mesh(
             cf. endpoint in numpy.linspace
 
     Returns:
-        (n, n, n, 3)-array: mesh
+        (3, n, n, n)-array: mesh
     """
     if n_mesh is None:
         if density is None:

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -5,10 +5,26 @@ from ase.atoms import Atoms
 
 def create_mesh(
     structure: Atoms,
-    n_mesh: int = 10,
-    density: int|None = None,
+    n_mesh: int|list = 10,
+    density: float|None = None,
     endpoint: bool = False
 ):
+    """
+    Create a mesh based on a structure
+
+    Args:
+        structure (ase.atoms.Atoms): ASE Atoms
+        n_mesh (int): Number of grid points in each direction. If one number
+            is given, it will be repeated in every direction (i.e. n_mesh = 3
+            is the same as n_mesh = [3, 3, 3])
+        density (float): Density of grid points. Ignored when n_mesh is not
+            None
+        endpoint (bool): Whether both the edges get separate points or not.
+            cf. endpoint in numpy.linspace
+
+    Returns:
+        (n, n, n, 3)-array: mesh
+    """
     if n_mesh is None:
         if density is None:
             raise ValueError("either n_mesh or density must be specified")

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -5,8 +5,12 @@ import warnings
 import typing
 
 
+class MeshInputError(ValueError):
+    """ Raised when mesh input format is wrong """
+
+
 def create_mesh(
-    structure: "ase.atoms.Atoms",
+    structure: typing.Union["ase.atoms.Atoms", np.ndarray],
     n_mesh: typing.Union[int, list[int, int, int]] = 10,
     density: typing.Optional[float] = None,
     endpoint: bool = False
@@ -29,10 +33,13 @@ def create_mesh(
     """
     if n_mesh is None:
         if density is None:
-            raise ValueError("either n_mesh or density must be specified")
+            raise MeshInputError("either n_mesh or density must be specified")
         n_mesh = np.rint(np.linalg.norm(structure.cell, axis=-1) / density).astype(int)
     elif density is not None:
-        warnings.warn("As n_mesh is not `None`, `density` is ignored")
+        raise MeshInputError(
+            "You cannot set n_mesh at density at the same time. Set one of"
+            " them to None"
+        )
     n_mesh = np.atleast_1d(n_mesh).astype(int)
     if len(n_mesh) == 1:
         n_mesh = np.repeat(n_mesh, 3)

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -49,5 +49,5 @@ def create_mesh(
         raise MeshInputError("n_mesh must be a 3-dim vector")
     linspace = [np.linspace(0, 1, nn, endpoint=endpoint) for nn in n_mesh]
     x_mesh = np.meshgrid(*linspace, indexing='ij')
-    return np.einsum("ixyz,ij->jxyz", x_mesh, structure.cell)
+    return np.einsum("ixyz,ij->jxyz", x_mesh, cell)
 

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -3,8 +3,15 @@ import warnings
 from ase.atoms import Atoms
 
 
-def create_mesh(structure: Atoms, n_mesh=10, density=None, endpoint=False):
+def create_mesh(
+    structure: Atoms,
+    n_mesh: int = 10,
+    density: int|None = None,
+    endpoint: bool = False
+):
     if n_mesh is None:
+        if density is None:
+            raise ValueError("either n_mesh or density must be specified")
         n_mesh = np.rint(np.linalg.norm(structure.cell, axis=-1) / density).astype(int)
     elif density is not None:
         warnings.warn("As n_mesh is not `None`, `density` is ignored")

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -45,6 +45,8 @@ def create_mesh(
     n_mesh = np.atleast_1d(n_mesh).astype(int)
     if len(n_mesh) == 1:
         n_mesh = np.repeat(n_mesh, 3)
+    elif len(n_mesh) != 3:
+        raise ValueError("n_mesh must be a 3-dim vector")
     linspace = [np.linspace(0, 1, nn, endpoint=endpoint) for nn in n_mesh]
     x_mesh = np.meshgrid(*linspace, indexing='ij')
     return np.einsum("ixyz,ij->jxyz", x_mesh, structure.cell)

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import warnings
 import typing
+from structuretoolkit.common.helpers import get_cell
 
 
 class MeshInputError(ValueError):
@@ -10,7 +11,7 @@ class MeshInputError(ValueError):
 
 
 def create_mesh(
-    structure: typing.Union["ase.atoms.Atoms", np.ndarray],
+    cell: typing.Union["ase.atoms.Atoms", np.ndarray, list, float],
     n_mesh: typing.Union[int, list[int, int, int]] = 10,
     density: typing.Optional[float] = None,
     endpoint: bool = False
@@ -19,7 +20,7 @@ def create_mesh(
     Create a mesh based on a structure
 
     Args:
-        structure (ase.atoms.Atoms): ASE Atoms
+        cell (ase.atoms.Atoms|np.ndarray|list|float): ASE Atoms or cell
         n_mesh (int): Number of grid points in each direction. If one number
             is given, it will be repeated in every direction (i.e. n_mesh = 3
             is the same as n_mesh = [3, 3, 3])
@@ -31,6 +32,7 @@ def create_mesh(
     Returns:
         (3, n, n, n)-array: mesh
     """
+    cell = get_cell(cell)
     if n_mesh is None:
         if density is None:
             raise MeshInputError("either n_mesh or density must be specified")

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import warnings
 import typing
-from structuretoolkit.common.helpers import get_cell
+from structuretoolkit.common.helper import get_cell
 
 
 class MeshInputError(ValueError):

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -17,7 +17,7 @@ def create_mesh(
     endpoint: bool = False
 ):
     """
-    Create a mesh based on a structure
+    Create a mesh based on a structure cell
 
     Args:
         cell (ase.atoms.Atoms|np.ndarray|list|float): ASE Atoms or cell

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -1,12 +1,13 @@
 import numpy as np
 import warnings
 from ase.atoms import Atoms
+import typing
 
 
 def create_mesh(
     structure: Atoms,
-    n_mesh: int|list = 10,
-    density: float|None = None,
+    n_mesh: typing.Union[int, list] = 10,
+    density: typing.Optional[float] = None,
     endpoint: bool = False
 ):
     """

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -46,7 +46,7 @@ def create_mesh(
     if len(n_mesh) == 1:
         n_mesh = np.repeat(n_mesh, 3)
     elif len(n_mesh) != 3:
-        raise ValueError("n_mesh must be a 3-dim vector")
+        raise MeshInputError("n_mesh must be a 3-dim vector")
     linspace = [np.linspace(0, 1, nn, endpoint=endpoint) for nn in n_mesh]
     x_mesh = np.meshgrid(*linspace, indexing='ij')
     return np.einsum("ixyz,ij->jxyz", x_mesh, structure.cell)

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -6,7 +6,7 @@ import typing
 
 def create_mesh(
     structure: Atoms,
-    n_mesh: typing.Union[int, list] = 10,
+    n_mesh: typing.Union[int, list[int, int, int]] = 10,
     density: typing.Optional[float] = None,
     endpoint: bool = False
 ):

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -36,7 +36,7 @@ def create_mesh(
     if n_mesh is None:
         if density is None:
             raise MeshInputError("either n_mesh or density must be specified")
-        n_mesh = np.rint(np.linalg.norm(structure.cell, axis=-1) / density).astype(int)
+        n_mesh = np.rint(np.linalg.norm(cell, axis=-1) / density).astype(int)
     elif density is not None:
         raise MeshInputError(
             "You cannot set n_mesh at density at the same time. Set one of"

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -37,5 +37,5 @@ def create_mesh(
         n_mesh = np.repeat(n_mesh, 3)
     linspace = [np.linspace(0, 1, nn, endpoint=endpoint) for nn in n_mesh]
     x_mesh = np.meshgrid(*linspace, indexing='ij')
-    return np.einsum("ixyz,ij->xyzj", x_mesh, structure.cell)
+    return np.einsum("ixyz,ij->jxyz", x_mesh, structure.cell)
 

--- a/structuretoolkit/build/mesh.py
+++ b/structuretoolkit/build/mesh.py
@@ -1,0 +1,17 @@
+import numpy as np
+import warnings
+from ase.atoms import Atoms
+
+
+def create_mesh(structure: Atoms, n_mesh=10, density=None, endpoint=False):
+    if n_mesh is None:
+        n_mesh = np.rint(np.linalg.norm(structure.cell, axis=-1) / density).astype(int)
+    elif density is not None:
+        warnings.warn("As n_mesh is not `None`, `density` is ignored")
+    n_mesh = np.atleast_1d(n_mesh).astype(int)
+    if len(n_mesh) == 1:
+        n_mesh = np.repeat(n_mesh, 3)
+    linspace = [np.linspace(0, 1, nn, endpoint=endpoint) for nn in n_mesh]
+    x_mesh = np.meshgrid(*linspace, indexing='ij')
+    return np.einsum("ixyz,ij->xyzj", x_mesh, structure.cell)
+

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -10,20 +10,20 @@ import structuretoolkit as stk
 class TestMesh(unittest.TestCase):
     def test_mesh(self):
         structure = bulk("Al", cubic=True)
-        self.assertEqual(stk.create_mesh(structure, n_mesh=4).shape, (4, 4, 4, 3))
+        self.assertEqual(stk.create_mesh(structure, n_mesh=4).shape, (3, 4, 4, 4))
         with self.assertRaises(ValueError):
             stk.create_mesh(structure, n_mesh=None, density=None)
         self.assertEqual(
             stk.create_mesh(
                 structure, n_mesh=10, density=structure.cell[0, 0] / 4
             ).shape,
-            (10, 10, 10, 3),
+            (3, 10, 10, 10),
         )
         self.assertEqual(
             stk.create_mesh(
                 structure, n_mesh=None, density=structure.cell[0, 0] / 4
             ).shape,
-            (4, 4, 4, 3),
+            (3, 4, 4, 4),
         )
 
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -3,7 +3,6 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import unittest
-import numpy as np
 from ase.build import bulk
 import structuretoolkit as stk
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+import numpy as np
+from ase.build import bulk
+import structuretoolkit as stk
+
+
+
+class TestMesh(unittest.TestCase):
+    def test_mesh(self):
+        structure = bulk("Al", cubic=True)
+        self.assertEqual(stk.create_mesh(structure, n_mesh=4).shape, (4, 4, 4, 3))
+        with self.assertRaises(ValueError):
+            stk.create_mesh(structure, n_mesh=None, density=None)
+        self.assertEqual(stk.create_mesh(structure, n_mesh=10, density=structure.cell[0, 0] / 4).shape, (10, 10, 10, 3))
+        self.assertEqual(stk.create_mesh(structure, n_mesh=None, density=structure.cell[0, 0] / 4).shape, (4, 4, 4, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -13,19 +13,17 @@ class TestMesh(unittest.TestCase):
         self.assertEqual(stk.create_mesh(structure, n_mesh=4).shape, (3, 4, 4, 4))
         with self.assertRaises(stk.build.mesh.MeshInputError):
             stk.create_mesh(structure, n_mesh=None, density=None)
-        self.assertEqual(
+        with self.assertRaises(stk.build.mesh.MeshInputError):
             stk.create_mesh(
                 structure, n_mesh=10, density=structure.cell[0, 0] / 4
-            ).shape,
-            (3, 10, 10, 10),
-        )
+            )
         self.assertEqual(
             stk.create_mesh(
                 structure, n_mesh=None, density=structure.cell[0, 0] / 4
             ).shape,
             (3, 4, 4, 4),
         )
-        with assertRaises(ValueError):
+        with self.assertRaises(stk.build.mesh.MeshInputError):
             _ = stk.create_mesh(structure, n_mesh=[1, 2, 3, 4])
 
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -8,15 +8,24 @@ from ase.build import bulk
 import structuretoolkit as stk
 
 
-
 class TestMesh(unittest.TestCase):
     def test_mesh(self):
         structure = bulk("Al", cubic=True)
         self.assertEqual(stk.create_mesh(structure, n_mesh=4).shape, (4, 4, 4, 3))
         with self.assertRaises(ValueError):
             stk.create_mesh(structure, n_mesh=None, density=None)
-        self.assertEqual(stk.create_mesh(structure, n_mesh=10, density=structure.cell[0, 0] / 4).shape, (10, 10, 10, 3))
-        self.assertEqual(stk.create_mesh(structure, n_mesh=None, density=structure.cell[0, 0] / 4).shape, (4, 4, 4, 3))
+        self.assertEqual(
+            stk.create_mesh(
+                structure, n_mesh=10, density=structure.cell[0, 0] / 4
+            ).shape,
+            (10, 10, 10, 3),
+        )
+        self.assertEqual(
+            stk.create_mesh(
+                structure, n_mesh=None, density=structure.cell[0, 0] / 4
+            ).shape,
+            (4, 4, 4, 3),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -11,7 +11,7 @@ class TestMesh(unittest.TestCase):
     def test_mesh(self):
         structure = bulk("Al", cubic=True)
         self.assertEqual(stk.create_mesh(structure, n_mesh=4).shape, (3, 4, 4, 4))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(stk.build.mesh.MeshInputError):
             stk.create_mesh(structure, n_mesh=None, density=None)
         self.assertEqual(
             stk.create_mesh(

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -25,6 +25,8 @@ class TestMesh(unittest.TestCase):
             ).shape,
             (3, 4, 4, 4),
         )
+        with assertRaises(ValueError):
+            _ = stk.create_mesh(structure, n_mesh=[1, 2, 3, 4])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This module allows us to create mesh grid from atomistic structures that can be used in continuum calculations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added `create_mesh` functionality to generate a mesh grid from atomic structures.

- **Tests**
  - Added unit tests for the `create_mesh` function to ensure reliable performance with various parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->