### PR TITLE
Get cell

### DIFF
--- a/structuretoolkit/__init__.py
+++ b/structuretoolkit/__init__.py
@@ -51,6 +51,7 @@ from structuretoolkit.common import (
     get_wrapped_coordinates,
     pymatgen_to_ase,
     select_index,
+    get_cell,
 )
 
 # Visualize

--- a/structuretoolkit/common/__init__.py
+++ b/structuretoolkit/common/__init__.py
@@ -6,6 +6,7 @@ from structuretoolkit.common.helper import (
     get_vertical_length,
     get_wrapped_coordinates,
     select_index,
+    get_cell,
 )
 from structuretoolkit.common.pymatgen import (
     ase_to_pymatgen,

--- a/structuretoolkit/common/helper.py
+++ b/structuretoolkit/common/helper.py
@@ -234,7 +234,7 @@ def get_cell(cell: Union[Atoms, list, np.ndarray, float]):
     orthogonal cell.
 
     Args:
-        cell (Atoms|ndarray|list|float): Cell
+        cell (Atoms|ndarray|list|float|tuple): Cell
 
     Returns:
         (3, 3)-array: Cell
@@ -243,7 +243,14 @@ def get_cell(cell: Union[Atoms, list, np.ndarray, float]):
         return cell.cell
     # Convert float into (3,)-array. No effect if it is (3,3)-array or
     # (3,)-array. Raises error if the shape is not correct
-    cell = cell * np.ones(3)
+    try:
+        cell = cell * np.ones(3)
+    except ValueError:
+        raise ValueError(
+            "cell must be a float, (3,)-ndarray/list/tuple or"
+            " (3,3)-ndarray/list/tuple"
+        )
+
     if np.shape(cell) == (3, 3):
         return cell
     # Convert (3,)-array into (3,3)-array. Raises error if the shape is wrong

--- a/structuretoolkit/common/helper.py
+++ b/structuretoolkit/common/helper.py
@@ -254,4 +254,10 @@ def get_cell(cell: Union[Atoms, list, np.ndarray, float]):
     if np.shape(cell) == (3, 3):
         return cell
     # Convert (3,)-array into (3,3)-array. Raises error if the shape is wrong
-    return cell * np.eye(3)
+    try:
+        return cell * np.eye(3)
+    except ValueError:
+        raise ValueError(
+            "cell must be a float, (3,)-ndarray/list/tuple or"
+            " (3,3)-ndarray/list/tuple"
+        )

--- a/structuretoolkit/common/helper.py
+++ b/structuretoolkit/common/helper.py
@@ -247,8 +247,7 @@ def get_cell(cell: Union[Atoms, list, np.ndarray, float]):
         cell = cell * np.ones(3)
     except ValueError:
         raise ValueError(
-            "cell must be a float, (3,)-ndarray/list/tuple or"
-            " (3,3)-ndarray/list/tuple"
+            f"Invalid cell type or shape: {type(cell).__name__}, {np.shape(cell)}"
         )
 
     if np.shape(cell) == (3, 3):
@@ -258,6 +257,5 @@ def get_cell(cell: Union[Atoms, list, np.ndarray, float]):
         return cell * np.eye(3)
     except ValueError:
         raise ValueError(
-            "cell must be a float, (3,)-ndarray/list/tuple or"
-            " (3,3)-ndarray/list/tuple"
+            f"Invalid cell type or shape: {type(cell).__name__}, {np.shape(cell)}"
         )

--- a/structuretoolkit/common/helper.py
+++ b/structuretoolkit/common/helper.py
@@ -2,7 +2,7 @@ import numpy as np
 from ase.atoms import Atoms
 from ase.data import atomic_numbers
 from scipy.sparse import coo_matrix
-from typing import Optional
+from typing import Optional, Union
 
 
 def get_extended_positions(
@@ -226,3 +226,25 @@ def apply_strain(
     structure_copy.set_cell(cell, scale_atoms=True)
     if return_box:
         return structure_copy
+
+
+def get_cell(cell: Union[Atoms, list, np.ndarray, float]):
+    """
+    Get cell of an ase structure, or convert a float or a (3,)-array into a
+    orthogonal cell.
+
+    Args:
+        cell (Atoms|ndarray|list|float): Cell
+
+    Returns:
+        (3, 3)-array: Cell
+    """
+    if isinstance(cell, Atoms):
+        return cell.cell
+    # Convert float into (3,)-array. No effect if it is (3,3)-array or
+    # (3,)-array. Raises error if the shape is not correct
+    cell = cell * np.ones(3)
+    if np.shape(cell) == (3, 3):
+        return cell
+    # Convert (3,)-array into (3,3)-array. Raises error if the shape is wrong
+    return cell * np.eye(3)

--- a/structuretoolkit/visualize.py
+++ b/structuretoolkit/visualize.py
@@ -9,6 +9,8 @@ import numpy as np
 from typing import Optional
 from scipy.interpolate import interp1d
 
+from structuretoolkit.common.helper import get_cell
+
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal"
 __copyright__ = (
     "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
@@ -166,7 +168,7 @@ def _get_box_skeleton(cell: np.ndarray):
 
 
 def _draw_box_plotly(fig, structure, px, go):
-    cell = structure.cell
+    cell = get_cell(structure)
     data = fig.data
     for lines in _get_box_skeleton(cell):
         fig = px.line_3d(**{xx: vv for xx, vv in zip(["x", "y", "z"], lines.T)})

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,6 +20,8 @@ class TestHelpers(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             stk.get_cell(np.arange(4))
+        with self.assertRaises(ValueError):
+            stk.get_cell(np.ones((4, 3)))
 
 
 if __name__ == "__main__":

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,6 +18,8 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(
             atoms.cell.tolist(), stk.get_cell(atoms).tolist()
         )
+        with self.assertRaises(ValueError):
+            stk.get_cell(np.arange(4))
 
 
 if __name__ == "__main__":

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+import numpy as np
+from ase.build import bulk
+import structuretoolkit as stk
+
+
+class TestHelpers(unittest.TestCase):
+    def test_get_cell(self):
+        self.assertEqual((3 * np.eye(3)).tolist(), stk.get_cell(3).tolist())
+        self.assertEqual(
+            ([1, 2, 3] * np.eye(3)).tolist(), stk.get_cell([1, 2, 3]).tolist()
+        )
+        atoms = bulk("Fe")
+        self.assertEqual(
+            atoms.cell.tolist(), stk.get_cell(atoms).tolist()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Following [@liamhuber's suggestion](https://github.com/pyiron/structuretoolkit/pull/183#discussion_r1605285066), I created a converter. He says the function is already there, although I couldn't find it, but it doesn't mean that it's definitely no there, so I might end up closing this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new function to retrieve or convert the cell of an ASE structure.

- **Refactor**
  - Optimized the `_draw_box_plotly` function to use the new cell retrieval method.

- **Tests**
  - Added unit tests for the new cell retrieval function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->