### PR TITLE
Update scipy to 1.14.0

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -15,6 +15,6 @@ dependencies:
 - pyscal =2.10.18
 - pyxtal =0.6.7
 - scikit-learn =1.5.0
-- scipy =1.13.1
+- scipy =1.14.0
 - spglib =2.4.0
 - sqsgenerator =0.3

--- a/.ci_support/environment_mini.yml
+++ b/.ci_support/environment_mini.yml
@@ -4,4 +4,4 @@ dependencies:
 - ase =3.23.0
 - coverage
 - numpy =1.26.4
-- scipy =1.13.1
+- scipy =1.14.0

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -43,11 +43,6 @@ jobs:
           label: linux-64-py-3-10
           prefix: /usr/share/miniconda3/envs/my-env
 
-        - operating-system: ubuntu-latest
-          python-version: '3.9'
-          label: linux-64-py-3-9
-          prefix: /usr/share/miniconda3/envs/my-env
-
     steps:
     - uses: actions/checkout@v4
     - name: Merge conda environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "ase==3.23.0",
     "numpy==1.26.4",
-    "scipy==1.13.1",
+    "scipy==1.14.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `scipy` dependency to version `1.14.0` to ensure compatibility and access to the latest features.
  - Removed Python 3.9 setup from unit test workflow, now only supporting Python 3.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->