### PR TITLE
Symmetrize tensor

### DIFF
--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -234,7 +234,17 @@ class Symmetry(dict):
 
     def symmetrize_tensor(self, tensor: np.ndarray) -> np.ndarray:
         """
-        Symmetrization of a tensor
+        Symmetrization of any tensor. The tensor is defined by a matrix with a
+        shape of `n * (n_atoms, 3)`. For example, if the structure has 100
+        atoms, the vector can have a shape of (100, 3), (100, 3, 100, 3),
+        (100, 3, 100, 3, 100, 3) etc. Additionally, you can also have an array
+        of tensors, i.e. in this example you can have a shape like (4, 100, 3)
+        or (2, 100, 3, 100, 3). When the shape is (n, n_atoms, 3), the function
+        works in the same way as `symmetrize_vectors`, which might be somewhat
+        faster.
+
+        This function can be useful for the symmetrization of Hessian tensors,
+        or any other tensors which should be symmetric.
 
         Args:
             tensors (ndarray): n x (n_atoms x 3) tensor to symmetrize
@@ -413,10 +423,8 @@ class _SymmetrizeTensor:
     @cached_property
     def order(self):
         order = len(self._tensor.shape) // 2
-        assert (
-            self._tensor.shape[-2 * order :]
-            == order * self._sym._structure.positions.shape
-        )
+        if self._tensor.shape[-2 * order :] != order * self._sym._structure.positions.shape:
+            raise ValueError("Tensor must have a shape of a multiple of n_atoms x 3")
         return order
 
     @cached_property

--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -413,12 +413,15 @@ class _SymmetrizeTensor:
     @cached_property
     def order(self):
         order = len(self._tensor.shape) // 2
-        assert self._tensor.shape[-2 * order:] == order * self._sym._structure.positions.shape
+        assert (
+            self._tensor.shape[-2 * order :]
+            == order * self._sym._structure.positions.shape
+        )
         return order
 
     @cached_property
     def ij(self):
-        return string.ascii_lowercase[:2 * self.order]
+        return string.ascii_lowercase[: 2 * self.order]
 
     @property
     def IJ(self):
@@ -426,11 +429,15 @@ class _SymmetrizeTensor:
 
     @property
     def ij_reorder(self):
-        return "".join([self.ij[ii] for ii in np.arange(2 * self.order).reshape(-1, 2).T.flatten()])
+        return "".join(
+            [self.ij[ii] for ii in np.arange(2 * self.order).reshape(-1, 2).T.flatten()]
+        )
 
     @property
     def IJ_reorder(self):
-        return "".join([self.IJ[ii] for ii in np.arange(2 * self.order).reshape(2, -1).T.flatten()])
+        return "".join(
+            [self.IJ[ii] for ii in np.arange(2 * self.order).reshape(2, -1).T.flatten()]
+        )
 
     @cached_property
     def t_t(self):
@@ -438,9 +445,16 @@ class _SymmetrizeTensor:
 
     @cached_property
     def str_einsum(self):
-        return ",".join([
-            I + i for i, I in zip(self.ij[-self.order:], self.IJ[-self.order:])
-        ]) + "," + self.IJ[:self.order] + self.ij[self.order:] + "...->..." + self.IJ_reorder
+        return (
+            ",".join(
+                [I + i for i, I in zip(self.ij[-self.order :], self.IJ[-self.order :])]
+            )
+            + ","
+            + self.IJ[: self.order]
+            + self.ij[self.order :]
+            + "...->..."
+            + self.IJ_reorder
+        )
 
     @property
     def result(self):
@@ -448,11 +462,11 @@ class _SymmetrizeTensor:
             [
                 np.einsum(
                     self.str_einsum,
-                    * self.order * (rot, ),
-                    self.t_t[*np.meshgrid(* self.order * (perm,), indexing="ij")],
-                    optimize=True
+                    *self.order * (rot,),
+                    self.t_t[*np.meshgrid(*self.order * (perm,), indexing="ij")],
+                    optimize=True,
                 )
                 for rot, perm in zip(self._sym.rotations, self._sym.permutations)
             ],
-            axis=0
+            axis=0,
         )

--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -478,7 +478,7 @@ class _SymmetrizeTensor:
                 np.einsum(
                     self.str_einsum,
                     *self.order * (rot,),
-                    self.t_t[*np.meshgrid(*self.order * (perm,), indexing="ij")],
+                    self.t_t[tuple(np.meshgrid(*self.order * (perm,), indexing="ij"))],
                     optimize=True,
                 )
                 for rot, perm in zip(self._rotations, self._permutations)

--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -256,7 +256,7 @@ class Symmetry(dict):
             tensor=tensor,
             structure=self._structure,
             rotations=self.rotations,
-            permutations=self.permutations
+            permutations=self.permutations,
         ).result
 
     def _get_spglib_cell(

--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -247,7 +247,7 @@ class Symmetry(dict):
         or any other tensors which should be symmetric.
 
         Args:
-            tensors (ndarray): n x (n_atoms x 3) tensor to symmetrize
+            tensors (ndarray): n * (n_atoms, 3) tensor to symmetrize
 
         Returns
             (np.ndarray) symmetrized tensor of the same shape
@@ -431,7 +431,10 @@ class _SymmetrizeTensor:
     def order(self):
         order = len(self._tensor.shape) // 2
         if self._tensor.shape[-2 * order :] != order * self._structure.positions.shape:
-            raise ValueError("Tensor must have a shape of a multiple of n_atoms x 3")
+            raise ValueError(
+                "Tensor must have a shape of a multiple of (n_atoms, 3). See"
+                " docstring for more info"
+            )
         return order
 
     @cached_property

--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -268,7 +268,8 @@ class Symmetry(dict):
                     optimize=True,
                 )
                 for rot, perm in zip(self.rotations, self.permutations)
-            ]
+            ],
+            axis=0
         )
 
     def _get_spglib_cell(

--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -232,10 +232,7 @@ class Symmetry(dict):
             np.einsum("ijk->jki", v_reshaped)[self.permutations],
         ).reshape(np.shape(vectors)) / len(self["rotations"])
 
-    def symmetrize_tensor(
-        self,
-        tensor: np.ndarray
-    ) -> np.ndarray:
+    def symmetrize_tensor(self, tensor: np.ndarray) -> np.ndarray:
         """
         Symmetrization of a tensor
 
@@ -246,15 +243,33 @@ class Symmetry(dict):
             (np.ndarray) symmetrized tensor of the same shape
         """
         order = len(np.shape(tensor)) // 2
-        if np.shape(tensor)[-2 * order:] != order * self._structure.positions.shape:
+        if np.shape(tensor)[-2 * order :] != order * self._structure.positions.shape:
             raise ValueError(
                 "The tensor must have a shape of a multiplication of natoms x 3"
             )
-        ij = string.ascii_lowercase[:2 * order]
+        ij = string.ascii_lowercase[: 2 * order]
         IJ = ij.upper()
-        str_einsum = ",".join([I + i for i, I in zip(ij, IJ)]) + ",..." + ij + "->..." + IJ
+        str_einsum = (
+            ",".join([I + i for i, I in zip(ij, IJ)]) + ",..." + ij + "->..." + IJ
+        )
         n = len(self._structure)
-        return np.mean([np.einsum(str_einsum, * order * (csr_matrix((np.ones(n, dtype=int), (np.arange(n), perm)), shape=(n,n)).toarray(), rot), tensor, optimize=True) for rot, perm in zip(self.rotations, self.permutations)])
+        return np.mean(
+            [
+                np.einsum(
+                    str_einsum,
+                    *order
+                    * (
+                        csr_matrix(
+                            (np.ones(n, dtype=int), (np.arange(n), perm)), shape=(n, n)
+                        ).toarray(),
+                        rot,
+                    ),
+                    tensor,
+                    optimize=True,
+                )
+                for rot, perm in zip(self.rotations, self.permutations)
+            ]
+        )
 
     def _get_spglib_cell(
         self, use_elements: Optional[bool] = None, use_magmoms: Optional[bool] = None

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -314,7 +314,10 @@ class TestSymmetrizeTensors(unittest.TestCase):
         st = stk.analyse.symmetry._SymmetrizeTensor(
             tensor=np.random.randn(*2 * self.structure.positions.shape), **self.dataset
         )
-        print(st.ij)
+        self.assertEqual(st.ij, "abcd")
+        self.assertEqual(st.ij_reorder, "acbd")
+        self.assertEqual(st.IJ, "ABCD")
+        self.assertEqual(st.IJ_reorder, "ACBD")
 
 
 if __name__ == "__main__":

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -108,19 +108,20 @@ class TestAtoms(unittest.TestCase):
             "AlAl", scaled_positions=[(0, 0, 0), (0.5, 0.5, 0.5)], cell=cell, pbc=True
         )
         v = np.random.rand(6).reshape(-1, 3)
+        sym = stk.analyse.get_symmetry(structure=Al)
         self.assertAlmostEqual(
-            np.linalg.norm(
-                stk.analyse.get_symmetry(structure=Al).symmetrize_vectors(v)
-            ),
-            0,
+            np.linalg.norm(sym.symmetrize_vectors(v)), 0,
         )
         vv = np.random.rand(12).reshape(2, 2, 3)
-        for vvv in stk.analyse.get_symmetry(structure=Al).symmetrize_vectors(vv):
+        for vvv in sym.symmetrize_vectors(vv):
             self.assertAlmostEqual(np.linalg.norm(vvv), 0)
         Al.positions[0, 0] += 0.01
-        w = stk.analyse.get_symmetry(structure=Al).symmetrize_vectors(v)
+        w = sym.symmetrize_vectors(v)
         self.assertAlmostEqual(
             np.absolute(w[:, 0]).sum(), np.linalg.norm(w, axis=-1).sum()
+        )
+        self.assertAlmostEqual(
+            np.linalg.norm(sym.symmetrize_vectors(v) - sym.symmetrize_tensor(v)), 0
         )
 
     def test_get_symmetry_dataset(self):

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -284,5 +284,32 @@ class TestAtoms(unittest.TestCase):
             stk.analyse.get_symmetry(structure=structure)
 
 
+class TestSymmetrizeTensors(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.structure = bulk("Al", cubic=True, a=4.0).repeat(2)
+        cls.dataset = {
+            "structure": cls.structure,
+            "rotations": np.eye(3),
+            "permutations": np.arange(len(cls.structure))
+        }
+
+    def test_order(self):
+        with self.assertRaises(ValueError):
+            stk.analyse.symmetry._SymmetrizeTensor(tensor=np.array([1]), **self.dataset).order
+        self.assertEqual(
+            stk.analyse.symmetry._SymmetrizeTensor(
+                tensor=np.random.randn(*self.structure.positions.shape), **self.dataset
+            ).order,
+            1
+        )
+        self.assertEqual(
+            stk.analyse.symmetry._SymmetrizeTensor(
+                tensor=np.random.randn(*2 * self.structure.positions.shape), **self.dataset
+            ).order,
+            2
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -319,6 +319,16 @@ class TestSymmetrizeTensors(unittest.TestCase):
         self.assertEqual(st.IJ, "ABCD")
         self.assertEqual(st.IJ_reorder, "ACBD")
 
+    def test_str_einsum(self):
+        st = stk.analyse.symmetry._SymmetrizeTensor(
+            tensor=np.random.randn(*2 * self.structure.positions.shape), **self.dataset
+        )
+        self.assertEqual(st.str_einsum, "Cc,Dd,ABcd...->...ACBD")
+        st = stk.analyse.symmetry._SymmetrizeTensor(
+            tensor=np.random.randn(*self.structure.positions.shape), **self.dataset
+        )
+        self.assertEqual(st.str_einsum, "Bb,Ab...->...AB")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -110,7 +110,8 @@ class TestAtoms(unittest.TestCase):
         v = np.random.rand(6).reshape(-1, 3)
         sym = stk.analyse.get_symmetry(structure=Al)
         self.assertAlmostEqual(
-            np.linalg.norm(sym.symmetrize_vectors(v)), 0,
+            np.linalg.norm(sym.symmetrize_vectors(v)),
+            0,
         )
         vv = np.random.rand(12).reshape(2, 2, 3)
         for vvv in sym.symmetrize_vectors(vv):
@@ -156,7 +157,7 @@ class TestAtoms(unittest.TestCase):
         )
 
     def test_get_primitive_cell_hex(self):
-        elements = ['Fe', 'Fe', 'Fe', 'Fe', 'O', 'O', 'O', 'O', 'O', 'O']
+        elements = ["Fe", "Fe", "Fe", "Fe", "O", "O", "O", "O", "O", "O"]
         positions = [
             [0.0, 0.0, 4.89],
             [0.0, 0.0, 11.78],
@@ -175,8 +176,7 @@ class TestAtoms(unittest.TestCase):
         sym = stk.analyse.get_symmetry(structure=structure_repeat)
         structure_prim_base = sym.get_primitive_cell()
         self.assertEqual(
-            structure_prim_base.get_chemical_symbols(),
-            structure.get_chemical_symbols()
+            structure_prim_base.get_chemical_symbols(), structure.get_chemical_symbols()
         )
 
     def test_get_equivalent_points(self):
@@ -292,23 +292,26 @@ class TestSymmetrizeTensors(unittest.TestCase):
         cls.dataset = {
             "structure": cls.structure,
             "rotations": np.eye(3),
-            "permutations": np.arange(len(cls.structure))
+            "permutations": np.arange(len(cls.structure)),
         }
 
     def test_order(self):
         with self.assertRaises(ValueError):
-            stk.analyse.symmetry._SymmetrizeTensor(tensor=np.array([1]), **self.dataset).order
+            stk.analyse.symmetry._SymmetrizeTensor(
+                tensor=np.array([1]), **self.dataset
+            ).order
         self.assertEqual(
             stk.analyse.symmetry._SymmetrizeTensor(
                 tensor=np.random.randn(*self.structure.positions.shape), **self.dataset
             ).order,
-            1
+            1,
         )
         self.assertEqual(
             stk.analyse.symmetry._SymmetrizeTensor(
-                tensor=np.random.randn(*2 * self.structure.positions.shape), **self.dataset
+                tensor=np.random.randn(*2 * self.structure.positions.shape),
+                **self.dataset,
             ).order,
-            2
+            2,
         )
 
     def test_indexing(self):

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -7,6 +7,7 @@ import numpy as np
 from ase.build import bulk
 from ase.atoms import Atoms
 import structuretoolkit as stk
+from structuretoolkit.analyse.symmetry import _SymmetrizeTensor
 
 try:
     import pyscal
@@ -297,17 +298,17 @@ class TestSymmetrizeTensors(unittest.TestCase):
 
     def test_order(self):
         with self.assertRaises(ValueError):
-            stk.analyse.symmetry._SymmetrizeTensor(
+            _SymmetrizeTensor(
                 tensor=np.array([1]), **self.dataset
             ).order
         self.assertEqual(
-            stk.analyse.symmetry._SymmetrizeTensor(
+            _SymmetrizeTensor(
                 tensor=np.random.randn(*self.structure.positions.shape), **self.dataset
             ).order,
             1,
         )
         self.assertEqual(
-            stk.analyse.symmetry._SymmetrizeTensor(
+            _SymmetrizeTensor(
                 tensor=np.random.randn(*2 * self.structure.positions.shape),
                 **self.dataset,
             ).order,
@@ -315,7 +316,7 @@ class TestSymmetrizeTensors(unittest.TestCase):
         )
 
     def test_indexing(self):
-        st = stk.analyse.symmetry._SymmetrizeTensor(
+        st = _SymmetrizeTensor(
             tensor=np.random.randn(*2 * self.structure.positions.shape), **self.dataset
         )
         self.assertEqual(st.ij, "abcd")
@@ -324,11 +325,11 @@ class TestSymmetrizeTensors(unittest.TestCase):
         self.assertEqual(st.IJ_reorder, "ACBD")
 
     def test_str_einsum(self):
-        st = stk.analyse.symmetry._SymmetrizeTensor(
+        st = _SymmetrizeTensor(
             tensor=np.random.randn(*2 * self.structure.positions.shape), **self.dataset
         )
         self.assertEqual(st.str_einsum, "Cc,Dd,ABcd...->...ACBD")
-        st = stk.analyse.symmetry._SymmetrizeTensor(
+        st = _SymmetrizeTensor(
             tensor=np.random.randn(*self.structure.positions.shape), **self.dataset
         )
         self.assertEqual(st.str_einsum, "Bb,Ab...->...AB")

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -7,7 +7,6 @@ import numpy as np
 from ase.build import bulk
 from ase.atoms import Atoms
 import structuretoolkit as stk
-from structuretoolkit.analyse.symmetry import _SymmetrizeTensor
 
 try:
     import pyscal
@@ -19,6 +18,7 @@ except ImportError:
 
 try:
     import spglib
+    from structuretoolkit.analyse.symmetry import _SymmetrizeTensor
 
     skip_spglib_test = False
 except ImportError:

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -286,6 +286,9 @@ class TestAtoms(unittest.TestCase):
             stk.analyse.get_symmetry(structure=structure)
 
 
+@unittest.skipIf(
+    skip_spglib_test, "spglib is not installed, so the spglib tests are skipped."
+)
 class TestSymmetrizeTensors(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -310,6 +310,12 @@ class TestSymmetrizeTensors(unittest.TestCase):
             2
         )
 
+    def test_indexing(self):
+        st = stk.analyse.symmetry._SymmetrizeTensor(
+            tensor=np.random.randn(*2 * self.structure.positions.shape), **self.dataset
+        )
+        print(st.ij)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I implemented `symmetrize_tensor`, which is the generalisation of `symmetrize_vector`. With `symmetrize_tensor`, you can symmetrize any tensor. This is useful when something like a Hessian matrix should be symmetrized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced tensor symmetrization functionality, enabling users to symmetrize tensors like Hessian tensors.
  
- **Tests**
  - Added new test cases to verify tensor symmetrization, including order, indexing, and string representation tests for symmetrized tensors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->