### PR TITLE
Use dataclass interface to spglib symmetry

### DIFF
--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -66,9 +66,9 @@ class Symmetry(dict):
         self._angle_tolerance = angle_tolerance
         self.epsilon = epsilon
         self._permutations = None
-        for k, v in dataclasses.asdict(self._get_symmetry(
-            symprec=symprec, angle_tolerance=angle_tolerance
-        )).items():
+        for k, v in dataclasses.asdict(
+            self._get_symmetry(symprec=symprec, angle_tolerance=angle_tolerance)
+        ).items():
             self[k] = v
 
     @property


### PR DESCRIPTION
Using dict like interface throws deprecation warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the processing of symmetry data to ensure consistent handling as a standard dictionary, enhancing compatibility with other components.
  
- **Refactor**
	- Streamlined the initialization process of the class by utilizing `dataclasses.asdict()` for better clarity and consistency in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->