### PR TITLE
Use dataclass interface to spglib symmetry

### DIFF
--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import ast
+import dataclasses
 import string
 from functools import cached_property
 from typing import Optional
@@ -341,11 +342,11 @@ class Symmetry(dict):
 
         https://atztogo.github.io/spglib/python-spglib.html
         """
-        info = spglib.get_symmetry_dataset(
+        info = dataclasses.asdict(spglib.get_symmetry_dataset(
             cell=self._get_spglib_cell(use_magmoms=False),
             symprec=self._symprec,
             angle_tolerance=self._angle_tolerance,
-        )
+        ))
         if info is None:
             raise SymmetryError(spglib.spglib.spglib_error.message)
         return info

--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -353,7 +353,6 @@ class Symmetry(dict):
             info = dataclasses.asdict(info)
         return info
 
-
     @property
     def spacegroup(self) -> dict:
         """

--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -342,14 +342,17 @@ class Symmetry(dict):
 
         https://atztogo.github.io/spglib/python-spglib.html
         """
-        info = dataclasses.asdict(spglib.get_symmetry_dataset(
+        info = spglib.get_symmetry_dataset(
             cell=self._get_spglib_cell(use_magmoms=False),
             symprec=self._symprec,
             angle_tolerance=self._angle_tolerance,
-        ))
+        )
         if info is None:
             raise SymmetryError(spglib.spglib.spglib_error.message)
+        if dataclasses.is_dataclass(info):
+            info = dataclasses.asdict(info)
         return info
+
 
     @property
     def spacegroup(self) -> dict:


### PR DESCRIPTION
spglib.get_symmetry_dataset now returns a dataclass and throws warnings on __getitem__.  This affects our Symmetry class when using the .info attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the symmetry dataset output by converting it into a more accessible dictionary format, improving usability for end-users.
  
- **Bug Fixes**
	- Maintained existing error handling for cases where the symmetry dataset is `None`, ensuring stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->