### PR TITLE
[bugfix] Divide the symmetrized tensor by the number of symmetries

### DIFF
--- a/structuretoolkit/analyse/symmetry.py
+++ b/structuretoolkit/analyse/symmetry.py
@@ -260,7 +260,7 @@ class Symmetry(dict):
             *sum([s == 3 for s in tensor.shape]) * [self.rotations],
             v,
             optimize=True,
-        )
+        ) / len(self.rotations)
 
     def _get_spglib_cell(
         self, use_elements: Optional[bool] = None, use_magmoms: Optional[bool] = None

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -129,7 +129,7 @@ class TestSymmetry(unittest.TestCase):
         sym = stk.analyse.get_symmetry(structure=Al)
         tensor = np.zeros((len(Al), 3, len(Al), 3))
         tensor[0, 0, 0, 0] = 1
-        self.assertAlmostEqual(sym.symmetrize_vectors(tensor), 1)
+        self.assertAlmostEqual(sym.symmetrize_vectors(tensor)[0, 0, 0, 0], 1)
 
     def test_symmetrize_tensor(self):
         structure = Atoms(

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -126,10 +126,6 @@ class TestSymmetry(unittest.TestCase):
         self.assertAlmostEqual(
             np.linalg.norm(sym.symmetrize_vectors(v) - sym.symmetrize_tensor(v)), 0
         )
-        sym = stk.analyse.get_symmetry(structure=Al)
-        tensor = np.zeros((len(Al), 3, len(Al), 3))
-        tensor[0, 0, 0, 0] = 1
-        self.assertAlmostEqual(sym.symmetrize_vectors(tensor)[0, 0, 0, 0], 1)
 
     def test_symmetrize_tensor(self):
         structure = Atoms(
@@ -156,6 +152,12 @@ class TestSymmetry(unittest.TestCase):
             np.random.randn(4, len(structure), 3, 3, len(structure))
         )
         self.assertEqual(s_tensor.shape, (4, len(structure), 3, 3, len(structure)))
+        structure_displaced = structure.copy()
+        structure_displaced.positions[0, 0] += 0.01
+        sym = stk.analyse.get_symmetry(structure=structure_displaced)
+        tensor = np.zeros((len(structure_displaced), 3, len(structure_displaced), 3))
+        tensor[0, 0, 0, 0] = 1
+        self.assertAlmostEqual(sym.symmetrize_tensor(tensor)[0, 0, 0, 0], 1)
 
     def test_get_symmetry_dataset(self):
         cell = 2.2 * np.identity(3)

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -126,6 +126,10 @@ class TestSymmetry(unittest.TestCase):
         self.assertAlmostEqual(
             np.linalg.norm(sym.symmetrize_vectors(v) - sym.symmetrize_tensor(v)), 0
         )
+        sym = stk.analyse.get_symmetry(structure=Al)
+        tensor = np.zeros((len(Al), 3, len(Al), 3))
+        tensor[0, 0, 0, 0] = 1
+        self.assertAlmostEqual(sym.symmetrize_vectors(tensor), 1)
 
     def test_symmetrize_tensor(self):
         structure = Atoms(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tensor symmetrization by averaging over all symmetry operations for more accurate results.
* **Tests**
  * Enhanced test coverage to validate tensor symmetrization with specific tensor inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->