### PR TITLE
Test with Python 3.13

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: '3.12'
+        python-version: '3.13'
         miniforge-version: latest
         condarc-file: .condarc
         environment-file: .ci_support/environment_mini.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: '3.12'
+        python-version: '3.13'
         miniforge-version: latest
         condarc-file: .condarc
         environment-file: .ci_support/environment.yml
@@ -92,12 +92,16 @@ jobs:
       matrix:
         include:
         - operating-system: windows-latest
-          python-version: '3.12'
-          label: win-64-py-3-12
+          python-version: '3.13'
+          label: win-64-py-3-13
 
         - operating-system: macos-latest
-          python-version: '3.12'
-          label: osx-64-py-3-12
+          python-version: '3.13'
+          label: osx-64-py-3-13
+
+        - operating-system: ubuntu-latest
+          python-version: '3.13'
+          label: linux-64-py-3-13
 
         - operating-system: ubuntu-latest
           python-version: '3.12'
@@ -130,7 +134,7 @@ jobs:
         coverage run
         coverage xml
     - name: Upload coverage reports to Codecov
-      if: matrix.label == 'linux-64-py-3-12'
+      if: matrix.label == 'linux-64-py-3-13'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["pyiron"]
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.9, <3.14"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Topic :: Scientific/Engineering :: Physics",
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "ase==3.26.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to run tests on Python 3.13 across Linux, macOS, and Windows; added an Ubuntu 3.13 job, aligned matrix labels, and adjusted coverage upload to target the 3.13 job.
* **Documentation**
  * Declared official Python 3.13 support in project metadata and classifiers; expanded compatibility range to >=3.9, <3.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->