### PR TITLE
Revert nglview to 3.1.4

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - coverage
 - dscribe =2.1.2
 - matplotlib-base =3.10.6
-- nglview =4.0
+- nglview =3.1.4
 - notebook
 - numpy =2.3.3
 - phonopy =2.43.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ grainboundary = [
     "pymatgen==2025.6.14",
 ]
 pyscal = ["pyscal3==3.3.0"]
-nglview = ["nglview==4.0"]
+nglview = ["nglview==3.1.4"]
 matplotlib = ["matplotlib==3.10.6"]
 plotly = ["plotly==6.3.1"]
 clusters = ["scikit-learn==1.7.2"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.
- Chores
  - Updated dependency pin: nglview set to version 3.1.4 across environment and optional install configurations.
  - Aligned conda environment and optional dependencies for consistency.
- Notes
  - If you rely on the optional 3D viewing component, reinstall or update your environment to ensure nglview 3.1.4 is used.
  - No other dependencies or configurations were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->