### PR TITLE
Extend unit tests for get_primitive_cell()

### DIFF
--- a/tests/test_analyse_symmetry.py
+++ b/tests/test_analyse_symmetry.py
@@ -425,6 +425,27 @@ class TestSymmetry(unittest.TestCase):
         dx_round = np.round(np.absolute(dx), decimals=3)
         self.assertEqual(len(np.unique(dx_round + arg_v)), len(np.unique(arg_v)))
 
+    def test_get_primitive_cell_pbc_error(self):
+        structure = bulk("Al", cubic=True)
+        structure.pbc = [True, True, False]
+        sym = stk.analyse.get_symmetry(structure=structure)
+        with self.assertRaisesRegex(ValueError, "Can only symmetrize periodic structures."):
+            sym.get_primitive_cell()
+
+    def test_get_primitive_cell_arrays_warning(self):
+        structure = bulk("Al", cubic=True)
+        structure.set_array("test_array", np.zeros(len(structure)))
+        sym = stk.analyse.get_symmetry(structure=structure)
+        with self.assertLogs(level="WARNING") as cm:
+            sym.get_primitive_cell()
+        self.assertTrue(
+            any(
+                "Custom arrays {'test_array'} do not carry over to new structure!"
+                in output
+                for output in cm.output
+            )
+        )
+
     def test_error(self):
         """spglib errors should be wrapped in a SymmetryError."""
 

--- a/tests/test_analyse_symmetry.py
+++ b/tests/test_analyse_symmetry.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import unittest
+import warnings
 
 import numpy as np
 from ase.atoms import Atoms
@@ -436,13 +437,14 @@ class TestSymmetry(unittest.TestCase):
         structure = bulk("Al", cubic=True)
         structure.set_array("test_array", np.zeros(len(structure)))
         sym = stk.analyse.get_symmetry(structure=structure)
-        with self.assertLogs(level="WARNING") as cm:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             sym.get_primitive_cell()
         self.assertTrue(
             any(
                 "Custom arrays {'test_array'} do not carry over to new structure!"
                 in output
-                for output in cm.output
+                for output in w
             )
         )
 

--- a/tests/test_analyse_symmetry.py
+++ b/tests/test_analyse_symmetry.py
@@ -443,8 +443,8 @@ class TestSymmetry(unittest.TestCase):
         self.assertTrue(
             any(
                 "Custom arrays {'test_array'} do not carry over to new structure!"
-                in output
-                for output in w
+                in str(warning.message)
+                for warning in w
             )
         )
 


### PR DESCRIPTION
This PR extends the unit tests for the `get_primitive_cell()` function in `src/structuretoolkit/analyse/symmetry.py`.

The new tests in `tests/test_analyse_symmetry.py` verify:
1. That a `ValueError` with the message "Can only symmetrize periodic structures." is raised when the input structure does not have all periodic boundary conditions set to `True`.
2. That a warning "Custom arrays {'...'} do not carry over to new structure!" is logged when the input structure contains custom arrays that are not preserved in the primitive cell.

These additions ensure better coverage of the validation and notification logic within `get_primitive_cell()`.

---
*PR created automatically by Jules for task [17824912344481522576](https://jules.google.com/task/17824912344481522576) started by @jan-janssen*