### PR TITLE
Return ASE atoms rather than MSONAtoms

### DIFF
--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 dependencies:
 - aimsgb =1.0.2
-- ase =3.20.1
+- ase =3.24.0
 - matplotlib-base =3.8.0
 - nglview =2.7.7
 - numpy =1.23.5

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -8,7 +8,7 @@ dependencies:
 - numpy =1.23.5
 - phonopy =2.16.2
 - plotly =4.14.3
-- pymatgen =2022.2.1
+- pymatgen =2026.3.23
 - pyscal3 =3.2.5
 - scikit-learn =1.2.1
 - scipy =1.15.0

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 - aimsgb =1.0.2
 - ase =3.20.1
-- matplotlib-base =3.6.2
+- matplotlib-base =3.8.0
 - nglview =2.7.7
 - numpy =1.23.5
 - phonopy =2.21.2

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -7,7 +7,7 @@ dependencies:
 - nglview =2.7.7
 - numpy =1.23.5
 - phonopy =2.21.2
-- plotly =5.0.0
+- plotly =6.0.0
 - pymatgen =2026.3.23
 - pyscal3 =3.2.5
 - scikit-learn =1.2.1

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -3,11 +3,11 @@ channels:
 dependencies:
 - aimsgb =1.0.2
 - ase =3.20.1
-- matplotlib-base =3.5.3
+- matplotlib-base =3.6.2
 - nglview =2.7.7
 - numpy =1.23.5
-- phonopy =2.16.2
-- plotly =4.14.3
+- phonopy =2.21.2
+- plotly =5.0.0
 - pymatgen =2026.3.23
 - pyscal3 =3.2.5
 - scikit-learn =1.2.1

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         miniforge-version: latest
         condarc-file: .condarc
         environment-file: .ci_support/environment-old.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/src/structuretoolkit/common/pymatgen.py
+++ b/src/structuretoolkit/common/pymatgen.py
@@ -12,7 +12,7 @@ def pymatgen_to_ase(structure) -> Atoms:
     from pymatgen.io.ase import AseAtomsAdaptor
 
     adapter = AseAtomsAdaptor()
-    return adapter.get_atoms(structure=structure)
+    return adapter.get_atoms(structure=structure, msonable=False)
 
 
 def pymatgen_read_from_file(*args, **kwargs) -> Atoms:

--- a/tests/test_pymatgen_mocked.py
+++ b/tests/test_pymatgen_mocked.py
@@ -54,7 +54,7 @@ class TestPymatgenMocked(unittest.TestCase):
         ):
             result = pymatgen_to_ase(mock_pymatgen_struct)
         self.assertEqual(result, mock_ase_atoms)
-        mock_adapter.get_atoms.assert_called_once_with(structure=mock_pymatgen_struct)
+        mock_adapter.get_atoms.assert_called_once_with(structure=mock_pymatgen_struct, msonable=False)
 
     def test_pymatgen_read_from_file(self):
         from structuretoolkit.common.pymatgen import pymatgen_read_from_file


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pymatgen structure conversion to adjust output representation in ASE format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyiron/structuretoolkit/pull/497)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->