### PR TITLE
Fix lammps create_atoms() TypeError from renamed atomid/atype keywords

### DIFF
--- a/notebooks/introduction.ipynb
+++ b/notebooks/introduction.ipynb
@@ -60,14 +60,16 @@
    "source": [
     "import warnings\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\")  # silence third-party deprecation warnings for this demo\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\"\n",
+    ")  # silence third-party deprecation warnings for this demo\n",
     "\n",
     "import numpy as np\n",
     "from ase.build import bulk\n",
     "\n",
     "import structuretoolkit as stk\n",
     "\n",
-    "print(\"structuretoolkit version:\", stk.__version__)\n"
+    "print(\"structuretoolkit version:\", stk.__version__)"
    ]
   },
   {
@@ -121,7 +123,10 @@
     "structure = bulk(\"Fe\", cubic=True).repeat(2) + bulk(\"Al\", cubic=True).repeat((2, 1, 1))\n",
     "\n",
     "print(\"Number of atoms per species:\", stk.common.get_number_species_atoms(structure))\n",
-    "print(\"Indices of the Al atoms:\", stk.common.select_index(structure=structure, element=\"Al\"))\n"
+    "print(\n",
+    "    \"Indices of the Al atoms:\",\n",
+    "    stk.common.select_index(structure=structure, element=\"Al\"),\n",
+    ")"
    ]
   },
   {
@@ -178,17 +183,23 @@
     "fe_bulk = bulk(\"Fe\", cubic=True)\n",
     "\n",
     "print(\"Normalised (3, 3) cell from a lattice constant:\\n\", stk.common.get_cell(2.87))\n",
-    "print(\"\\nVertical heights of the Fe cell:\", stk.common.get_vertical_length(structure=fe_bulk))\n",
+    "print(\n",
+    "    \"\\nVertical heights of the Fe cell:\",\n",
+    "    stk.common.get_vertical_length(structure=fe_bulk),\n",
+    ")\n",
     "\n",
     "extended_positions, original_indices = stk.common.get_extended_positions(\n",
     "    structure=fe_bulk, width=3.0, return_indices=True\n",
     ")\n",
-    "print(\"\\nAtoms after adding a 3 Angstrom buffer layer around the cell:\", len(extended_positions))\n",
+    "print(\n",
+    "    \"\\nAtoms after adding a 3 Angstrom buffer layer around the cell:\",\n",
+    "    len(extended_positions),\n",
+    ")\n",
     "\n",
     "shifted = fe_bulk.copy()\n",
     "shifted.positions += 5 * np.diag(shifted.cell)  # move atoms several cells away\n",
     "stk.common.center_coordinates_in_unit_cell(structure=shifted)\n",
-    "print(\"\\nPositions after wrapping back into the cell:\\n\", shifted.positions)\n"
+    "print(\"\\nPositions after wrapping back into the cell:\\n\", shifted.positions)"
    ]
   },
   {
@@ -231,7 +242,7 @@
     "strained = stk.common.apply_strain(structure=structure, epsilon=0.01, return_box=True)\n",
     "\n",
     "print(\"Original volume:  \", structure.get_volume())\n",
-    "print(\"Strained volume:  \", strained.get_volume())\n"
+    "print(\"Strained volume:  \", strained.get_volume())"
    ]
   },
   {
@@ -315,7 +326,10 @@
     "\n",
     "phonopy_atoms = stk.common.atoms_to_phonopy(atom=fe_bulk)\n",
     "print(\"\\nphonopy atoms:\", type(phonopy_atoms))\n",
-    "print(\"Round-tripped through phonopy:\", stk.common.phonopy_to_atoms(ph_atoms=phonopy_atoms))\n"
+    "print(\n",
+    "    \"Round-tripped through phonopy:\",\n",
+    "    stk.common.phonopy_to_atoms(ph_atoms=phonopy_atoms),\n",
+    ")"
    ]
   },
   {
@@ -388,7 +402,7 @@
     "\n",
     "print(\"Distance to the 8 nearest neighbors of atom 0:\\n\", neigh.distances[0])\n",
     "print(\"\\nCoordination shell of each of those neighbors:\\n\", neigh.shells[0])\n",
-    "print(\"\\nChemical symbols of the neighbors of atom 0:\\n\", neigh.chemical_symbols[0])\n"
+    "print(\"\\nChemical symbols of the neighbors of atom 0:\\n\", neigh.chemical_symbols[0])"
    ]
   },
   {
@@ -427,7 +441,10 @@
     "neigh_point = stk.analyse.get_neighborhood(\n",
     "    structure=structure, positions=random_point_in_cell, num_neighbors=4\n",
     ")\n",
-    "print(\"Distances from a random point in the cell to its 4 nearest atoms:\\n\", neigh_point.distances)\n"
+    "print(\n",
+    "    \"Distances from a random point in the cell to its 4 nearest atoms:\\n\",\n",
+    "    neigh_point.distances,\n",
+    ")"
    ]
   },
   {
@@ -477,7 +494,7 @@
     "\n",
     "displacement = structure.positions[0] - structure.positions[1] + 10 * structure.cell[0]\n",
     "mic_distance = stk.analyse.find_mic(structure=structure, v=displacement, vectors=False)\n",
-    "print(\"\\nDisplacement folded back via the minimum image convention:\", mic_distance)\n"
+    "print(\"\\nDisplacement folded back via the minimum image convention:\", mic_distance)"
    ]
   },
   {
@@ -555,15 +572,31 @@
     "print(\"Space group:\", stk.analyse.get_spacegroup(structure=structure))\n",
     "\n",
     "primitive = stk.analyse.get_primitive_cell(structure=structure)\n",
-    "print(\"\\nAtoms in the supercell vs. its primitive cell:\", len(structure), \"->\", len(primitive))\n",
+    "print(\n",
+    "    \"\\nAtoms in the supercell vs. its primitive cell:\",\n",
+    "    len(structure),\n",
+    "    \"->\",\n",
+    "    len(primitive),\n",
+    ")\n",
     "\n",
     "# Forces/displacements on a perfect crystal must symmetrize to (numerically) zero\n",
     "random_vectors = np.random.random(structure.positions.shape)\n",
     "print(\"\\nNorm of a random vector field before/after symmetrization:\")\n",
-    "print(np.linalg.norm(random_vectors), \"->\", np.linalg.norm(stk.analyse.symmetrize_vectors(structure, random_vectors)))\n",
+    "print(\n",
+    "    np.linalg.norm(random_vectors),\n",
+    "    \"->\",\n",
+    "    np.linalg.norm(stk.analyse.symmetrize_vectors(structure, random_vectors)),\n",
+    ")\n",
     "\n",
-    "mapping, grid_points = stk.analyse.get_ir_reciprocal_mesh(structure=structure, mesh=[4, 4, 4])\n",
-    "print(\"\\nIrreducible points of a 4x4x4 k-point mesh:\", len(np.unique(mapping)), \"out of\", len(grid_points))\n"
+    "mapping, grid_points = stk.analyse.get_ir_reciprocal_mesh(\n",
+    "    structure=structure, mesh=[4, 4, 4]\n",
+    ")\n",
+    "print(\n",
+    "    \"\\nIrreducible points of a 4x4x4 k-point mesh:\",\n",
+    "    len(np.unique(mapping)),\n",
+    "    \"out of\",\n",
+    "    len(grid_points),\n",
+    ")"
    ]
   },
   {
@@ -599,7 +632,7 @@
    ],
    "source": [
     "structure = bulk(\"Al\", cubic=True).repeat(2)\n",
-    "print(\"Equivalent-atom labels:\", stk.analyse.get_equivalent_atoms(structure=structure))\n"
+    "print(\"Equivalent-atom labels:\", stk.analyse.get_equivalent_atoms(structure=structure))"
    ]
   },
   {
@@ -656,15 +689,31 @@
     "print(\"Number of (111)-independent layers along x, y, z:\", layers.max(axis=0) + 1)\n",
     "\n",
     "voronoi_vertices = stk.analyse.get_voronoi_vertices(structure=bulk(\"Al\", cubic=True))\n",
-    "print(\"\\nVoronoi vertices of an fcc unit cell (octahedral + tetrahedral sites):\", len(voronoi_vertices))\n",
+    "print(\n",
+    "    \"\\nVoronoi vertices of an fcc unit cell (octahedral + tetrahedral sites):\",\n",
+    "    len(voronoi_vertices),\n",
+    ")\n",
     "\n",
     "voronoi_pairs = stk.analyse.get_voronoi_neighbors(structure=structure)\n",
     "delaunay_pairs = stk.analyse.get_delaunay_neighbors(structure=structure)\n",
-    "print(\"Voronoi neighbor pairs:\", len(voronoi_pairs), \" Delaunay neighbor pairs:\", len(delaunay_pairs))\n",
+    "print(\n",
+    "    \"Voronoi neighbor pairs:\",\n",
+    "    len(voronoi_pairs),\n",
+    "    \" Delaunay neighbor pairs:\",\n",
+    "    len(delaunay_pairs),\n",
+    ")\n",
     "\n",
     "doubled_positions = np.append(structure.positions, structure.positions, axis=0)\n",
-    "clustered = stk.analyse.get_cluster_positions(structure=structure, positions=doubled_positions)\n",
-    "print(\"\\nDuplicated positions clustered back down to:\", len(clustered), \"(original count:\", len(structure), \")\")\n"
+    "clustered = stk.analyse.get_cluster_positions(\n",
+    "    structure=structure, positions=doubled_positions\n",
+    ")\n",
+    "print(\n",
+    "    \"\\nDuplicated positions clustered back down to:\",\n",
+    "    len(clustered),\n",
+    "    \"(original count:\",\n",
+    "    len(structure),\n",
+    "    \")\",\n",
+    ")"
    ]
   },
   {
@@ -701,7 +750,7 @@
    "source": [
     "labels = [0, 1, 0, 2]\n",
     "values = [0, 1, 2, 3]\n",
-    "print(stk.analyse.get_average_of_unique_labels(labels=labels, values=values))\n"
+    "print(stk.analyse.get_average_of_unique_labels(labels=labels, values=values))"
    ]
   },
   {
@@ -756,7 +805,10 @@
     "\n",
     "print(\"Octahedral interstitial sites in bcc Fe:\", len(octahedral.positions))\n",
     "print(\"Tetrahedral interstitial sites in bcc Fe:\", len(tetrahedral.positions))\n",
-    "print(\"\\nDistance of the octahedral sites to their nearest neighbor atoms:\", octahedral.get_distances())\n"
+    "print(\n",
+    "    \"\\nDistance of the octahedral sites to their nearest neighbor atoms:\",\n",
+    "    octahedral.get_distances(),\n",
+    ")"
    ]
   },
   {
@@ -800,7 +852,7 @@
     "\n",
     "strain = stk.analyse.get_strain(structure=deformed, ref_structure=reference)\n",
     "print(\"Strain tensor shape:\", strain.shape)\n",
-    "print(\"Per-atom isotropic strain (trace / 3):\", np.trace(strain, axis1=1, axis2=2) / 3)\n"
+    "print(\"Per-atom isotropic strain (trace / 3):\", np.trace(strain, axis1=1, axis2=2) / 3)"
    ]
   },
   {
@@ -875,8 +927,14 @@
     "bcc_fe = bulk(\"Fe\", cubic=True)\n",
     "diamond_si = bulk(\"Si\", crystalstructure=\"diamond\", a=5.43, cubic=True)\n",
     "\n",
-    "print(\"Common neighbor analysis of bcc Fe:\", stk.analyse.get_adaptive_cna_descriptors(structure=bcc_fe))\n",
-    "print(\"Diamond-structure analysis of Si:  \", stk.analyse.get_diamond_structure_descriptors(structure=diamond_si))\n",
+    "print(\n",
+    "    \"Common neighbor analysis of bcc Fe:\",\n",
+    "    stk.analyse.get_adaptive_cna_descriptors(structure=bcc_fe),\n",
+    ")\n",
+    "print(\n",
+    "    \"Diamond-structure analysis of Si:  \",\n",
+    "    stk.analyse.get_diamond_structure_descriptors(structure=diamond_si),\n",
+    ")\n",
     "\n",
     "centro = stk.analyse.get_centro_symmetry_descriptors(structure=bcc_fe, num_neighbors=8)\n",
     "print(\"\\nCentrosymmetry parameter of perfect bcc Fe (should be ~0):\", centro)\n",
@@ -884,8 +942,15 @@
     "q, cluster_id = stk.analyse.get_steinhardt_parameters(structure=bcc_fe.repeat(3))\n",
     "print(\"\\nSteinhardt parameters q4, q6 shape:\", q.shape)\n",
     "\n",
-    "print(\"\\nVoronoi cell volume per atom:\", stk.analyse.get_voronoi_volumes(structure=bcc_fe))\n",
-    "print(\"Number of solid-like atoms (out of\", len(bcc_fe), \"):\", stk.analyse.find_solids(structure=bcc_fe))\n"
+    "print(\n",
+    "    \"\\nVoronoi cell volume per atom:\", stk.analyse.get_voronoi_volumes(structure=bcc_fe)\n",
+    ")\n",
+    "print(\n",
+    "    \"Number of solid-like atoms (out of\",\n",
+    "    len(bcc_fe),\n",
+    "    \"):\",\n",
+    "    stk.analyse.find_solids(structure=bcc_fe),\n",
+    ")"
    ]
   },
   {
@@ -929,8 +994,10 @@
    "source": [
     "cu_fcc = bulk(\"Cu\", \"fcc\", a=3.6, cubic=True)\n",
     "\n",
-    "soap = stk.analyse.soap_descriptor_per_atom(structure=cu_fcc, r_cut=6.0, n_max=8, l_max=6)\n",
-    "print(\"SOAP descriptor shape (n_atoms, n_features):\", soap.shape)\n"
+    "soap = stk.analyse.soap_descriptor_per_atom(\n",
+    "    structure=cu_fcc, r_cut=6.0, n_max=8, l_max=6\n",
+    ")\n",
+    "print(\"SOAP descriptor shape (n_atoms, n_features):\", soap.shape)"
    ]
   },
   {
@@ -971,10 +1038,12 @@
     "# python-module releases, so this call is most reliable when structuretoolkit and your\n",
     "# LAMMPS installation are from a matching, recent release.\n",
     "try:\n",
-    "    snap_descriptors = stk.analyse.get_snap_descriptors_per_atom(structure=ni_fcc, atom_types=[\"Ni\"])\n",
+    "    snap_descriptors = stk.analyse.get_snap_descriptors_per_atom(\n",
+    "        structure=ni_fcc, atom_types=[\"Ni\"]\n",
+    "    )\n",
     "    print(\"SNAP descriptor shape (n_atoms, n_components):\", snap_descriptors.shape)\n",
     "except TypeError as error:\n",
-    "    print(\"Skipping execution - incompatible LAMMPS python module installed:\", error)\n"
+    "    print(\"Skipping execution - incompatible LAMMPS python module installed:\", error)"
    ]
   },
   {
@@ -1030,7 +1099,7 @@
     "c15 = stk.build.C15(\"Mg\", \"Cu\")  # cubic Laves phase MgCu2\n",
     "\n",
     "print(\"B2 FeAl: \", b2.get_chemical_formula(), \"cell =\", b2.cell.lengths())\n",
-    "print(\"C15 MgCu2:\", c15.get_chemical_formula(), \"cell =\", c15.cell.lengths())\n"
+    "print(\"C15 MgCu2:\", c15.get_chemical_formula(), \"cell =\", c15.cell.lengths())"
    ]
   },
   {
@@ -1097,7 +1166,7 @@
     "    layers=20,\n",
     "    vacuum=10,\n",
     ")\n",
-    "print(\"Resulting stepped/kinked Ni slab:\", slab)\n"
+    "print(\"Resulting stepped/kinked Ni slab:\", slab)"
    ]
   },
   {
@@ -1146,7 +1215,9 @@
     "gb_structure = stk.build.grainboundary(\n",
     "    axis=[0, 0, 1], sigma=5, plane=[1, 2, 0], initial_struct=al_bulk\n",
     ")\n",
-    "print(\"\\nNumber of atoms in the sigma=5 [0 0 1](1 2 0) grain boundary:\", len(gb_structure))\n"
+    "print(\n",
+    "    \"\\nNumber of atoms in the sigma=5 [0 0 1](1 2 0) grain boundary:\", len(gb_structure)\n",
+    ")"
    ]
   },
   {
@@ -1185,7 +1256,7 @@
    "source": [
     "structure = bulk(\"Al\", cubic=True)\n",
     "mesh = stk.create_mesh(cell=structure, n_mesh=4)\n",
-    "print(\"Mesh array shape (3 components, nx, ny, nz):\", mesh.shape)\n"
+    "print(\"Mesh array shape (3 components, nx, ny, nz):\", mesh.shape)"
    ]
   },
   {
@@ -1236,7 +1307,10 @@
     "\n",
     "sqs_structure = best_sqs.atoms()\n",
     "print(\"SQS composition:\", stk.common.get_number_species_atoms(sqs_structure))\n",
-    "print(\"Short-range order parameter array shape (n_shells, n_species, n_species):\", best_sqs.sro().shape)\n"
+    "print(\n",
+    "    \"Short-range order parameter array shape (n_shells, n_species, n_species):\",\n",
+    "    best_sqs.sro().shape,\n",
+    ")"
    ]
   },
   {
@@ -1291,7 +1365,7 @@
     "        \" e.g.:\\n\\n\"\n",
     "        \"    structures = list(stk.build.materialsproject_search('Fe', is_stable=True))\\n\"\n",
     "        \"    fe_ground_state = stk.build.materialsproject_by_id('mp-13')\"\n",
-    "    )\n"
+    "    )"
    ]
   },
   {
@@ -1333,7 +1407,7 @@
    "source": [
     "structure = bulk(\"Al\", cubic=True).repeat(2)\n",
     "fig = stk.visualize.plot3d(structure, mode=\"plotly\")\n",
-    "fig.show(renderer=\"png\", width=500, height=400, scale=2)\n"
+    "fig.show(renderer=\"png\", width=500, height=400, scale=2)"
    ]
   },
   {
@@ -1372,9 +1446,11 @@
     "displaced = bulk(\"Al\", cubic=True)\n",
     "displaced.positions[0] += [0.4, 0.0, 0.0]\n",
     "\n",
-    "centro = stk.analyse.get_centro_symmetry_descriptors(structure=displaced, num_neighbors=12)\n",
+    "centro = stk.analyse.get_centro_symmetry_descriptors(\n",
+    "    structure=displaced, num_neighbors=12\n",
+    ")\n",
     "fig = stk.visualize.plot3d(displaced, mode=\"plotly\", scalar_field=centro)\n",
-    "fig.show(renderer=\"png\", width=500, height=400, scale=2)\n"
+    "fig.show(renderer=\"png\", width=500, height=400, scale=2)"
    ]
   },
   {

--- a/notebooks/introduction.ipynb
+++ b/notebooks/introduction.ipynb
@@ -1,0 +1,1420 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a2c9d2cf",
+   "metadata": {},
+   "source": [
+    "# Introduction to `structuretoolkit`\n",
+    "\n",
+    "[`structuretoolkit`](https://github.com/pyiron/structuretoolkit) is a Python library for **building**,\n",
+    "**analysing** and **visualising** atomistic structures for materials science. It does not introduce a\n",
+    "new structure class of its own &ndash; instead it operates directly on the\n",
+    "[`ase.atoms.Atoms`](https://wiki.fysik.dtu.dk/ase/ase/atoms.html) object from the\n",
+    "[Atomic Simulation Environment (ASE)](https://wiki.fysik.dtu.dk/ase/). You can therefore think of\n",
+    "`structuretoolkit` as a large collection of additional, ASE-compatible functions: anything you can\n",
+    "build with `ase.build`, you can analyse and post-process with `structuretoolkit`, and the result is\n",
+    "again a plain `ase.atoms.Atoms` object that you can keep using with ASE (writing files, running an ASE\n",
+    "calculator, etc.).\n",
+    "\n",
+    "## How the package is organised\n",
+    "\n",
+    "The functionality is grouped into four submodules:\n",
+    "\n",
+    "* [`structuretoolkit.build`](https://github.com/pyiron/structuretoolkit/blob/main/src/structuretoolkit/build/__init__.py) &ndash; construct new structures (compounds, surfaces, grain boundaries, SQS, meshes, ...)\n",
+    "* [`structuretoolkit.analyse`](https://github.com/pyiron/structuretoolkit/blob/main/src/structuretoolkit/analyse/__init__.py) &ndash; analyse existing structures (neighbors, symmetry, strain, descriptors, ...)\n",
+    "* [`structuretoolkit.common`](https://github.com/pyiron/structuretoolkit/blob/main/src/structuretoolkit/common/__init__.py) &ndash; small helper functions and converters to other representations (pymatgen, phonopy, pyscal)\n",
+    "* `structuretoolkit.visualize` &ndash; 3d visualisation of structures\n",
+    "\n",
+    "All of these functions are also re-exported from the root of the package (e.g. `structuretoolkit.get_neighbors`)\n",
+    "for backwards compatibility, but **it is recommended to import functions through their submodule**\n",
+    "(`structuretoolkit.analyse.get_neighbors`) because that is where they are documented and grouped by\n",
+    "purpose. Throughout this notebook we therefore `import structuretoolkit as stk` and always call\n",
+    "functions as `stk.analyse.xxx()`, `stk.build.xxx()`, `stk.common.xxx()` or `stk.visualize.xxx()`.\n",
+    "\n",
+    "This notebook walks through (almost) every public function of `structuretoolkit`, grouped by submodule,\n",
+    "and shows how it is meant to be combined with ASE.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "78f3482d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:37.862599Z",
+     "iopub.status.busy": "2026-06-26T15:19:37.862114Z",
+     "iopub.status.idle": "2026-06-26T15:19:49.266290Z",
+     "shell.execute_reply": "2026-06-26T15:19:49.256252Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "structuretoolkit version: 0.0.46.dev1+g469f12abe\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")  # silence third-party deprecation warnings for this demo\n",
+    "\n",
+    "import numpy as np\n",
+    "from ase.build import bulk\n",
+    "\n",
+    "import structuretoolkit as stk\n",
+    "\n",
+    "print(\"structuretoolkit version:\", stk.__version__)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b01bd01",
+   "metadata": {},
+   "source": [
+    "## `structuretoolkit.common` &ndash; helpers and converters\n",
+    "\n",
+    "The `common` submodule contains small utility functions that are used throughout the rest of the\n",
+    "package, plus converters that translate an `ase.atoms.Atoms` object into the structure representations\n",
+    "used by other materials-science packages (`pymatgen`, `phonopy`, `pyscal`). They are handy on their own\n",
+    "whenever you need a quick property of a structure without writing the boilerplate yourself.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d17d0902",
+   "metadata": {},
+   "source": [
+    "### Basic structure properties\n",
+    "\n",
+    "`get_number_species_atoms()` counts how many atoms of each chemical element are present, and\n",
+    "`select_index()` returns the indices of all atoms of a given element &ndash; both operate directly on the\n",
+    "`Atoms` object returned by `ase.build.bulk()`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cd7870b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:49.277333Z",
+     "iopub.status.busy": "2026-06-26T15:19:49.276606Z",
+     "iopub.status.idle": "2026-06-26T15:19:49.302509Z",
+     "shell.execute_reply": "2026-06-26T15:19:49.298378Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of atoms per species: {'Al': 8, 'Fe': 16}\n",
+      "Indices of the Al atoms: [16 17 18 19 20 21 22 23]\n"
+     ]
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Fe\", cubic=True).repeat(2) + bulk(\"Al\", cubic=True).repeat((2, 1, 1))\n",
+    "\n",
+    "print(\"Number of atoms per species:\", stk.common.get_number_species_atoms(structure))\n",
+    "print(\"Indices of the Al atoms:\", stk.common.select_index(structure=structure, element=\"Al\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b62afc8f",
+   "metadata": {},
+   "source": [
+    "### Cell geometry\n",
+    "\n",
+    "* `get_cell()` turns a float, a 3-vector, a 3x3 matrix or an `Atoms` object into a normalised\n",
+    "  (3, 3) cell array - this is what most other functions use internally to accept flexible cell input.\n",
+    "* `get_vertical_length()` returns, for every cell vector, the height of the box measured perpendicular\n",
+    "  to the opposite face (the relevant length scale e.g. for slab thickness or periodic cutoffs).\n",
+    "* `get_extended_positions()` repeats the atoms across the periodic boundary so that a search for\n",
+    "  neighbors close to the cell boundary does not miss any periodic image.\n",
+    "* `get_wrapped_coordinates()` wraps arbitrary Cartesian coordinates back into the periodic cell.\n",
+    "* `center_coordinates_in_unit_cell()` re-wraps all atoms of a structure in place, e.g. after coordinates\n",
+    "  were shifted outside of `[0, 1)` in fractional units.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ec61ca78",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:49.313190Z",
+     "iopub.status.busy": "2026-06-26T15:19:49.312502Z",
+     "iopub.status.idle": "2026-06-26T15:19:49.351406Z",
+     "shell.execute_reply": "2026-06-26T15:19:49.336026Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Normalised (3, 3) cell from a lattice constant:\n",
+      " [[2.87 0.   0.  ]\n",
+      " [0.   2.87 0.  ]\n",
+      " [0.   0.   2.87]]\n",
+      "\n",
+      "Vertical heights of the Fe cell: [2.87 2.87 2.87]\n",
+      "\n",
+      "Atoms after adding a 3 Angstrom buffer layer around the cell: 91\n",
+      "\n",
+      "Positions after wrapping back into the cell:\n",
+      " [[-6.68890263e-16 -6.68890263e-16 -6.68890263e-16]\n",
+      " [ 1.43500000e+00  1.43500000e+00  1.43500000e+00]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "fe_bulk = bulk(\"Fe\", cubic=True)\n",
+    "\n",
+    "print(\"Normalised (3, 3) cell from a lattice constant:\\n\", stk.common.get_cell(2.87))\n",
+    "print(\"\\nVertical heights of the Fe cell:\", stk.common.get_vertical_length(structure=fe_bulk))\n",
+    "\n",
+    "extended_positions, original_indices = stk.common.get_extended_positions(\n",
+    "    structure=fe_bulk, width=3.0, return_indices=True\n",
+    ")\n",
+    "print(\"\\nAtoms after adding a 3 Angstrom buffer layer around the cell:\", len(extended_positions))\n",
+    "\n",
+    "shifted = fe_bulk.copy()\n",
+    "shifted.positions += 5 * np.diag(shifted.cell)  # move atoms several cells away\n",
+    "stk.common.center_coordinates_in_unit_cell(structure=shifted)\n",
+    "print(\"\\nPositions after wrapping back into the cell:\\n\", shifted.positions)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ce46e6a",
+   "metadata": {},
+   "source": [
+    "### Applying a homogeneous strain\n",
+    "\n",
+    "`apply_strain()` deforms the cell (and, by default, the atoms with it) according to a strain matrix\n",
+    "`epsilon`. With `mode=\"linear\"` the deformation gradient is `F = epsilon + 1`; with `mode=\"lagrangian\"`\n",
+    "`epsilon` is interpreted as the Lagrangian strain tensor `(F^T F - 1) / 2`, which must be symmetric.\n",
+    "Passing `return_box=True` leaves the original structure untouched and returns a strained copy instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "87625e89",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:49.360572Z",
+     "iopub.status.busy": "2026-06-26T15:19:49.359099Z",
+     "iopub.status.idle": "2026-06-26T15:19:49.384302Z",
+     "shell.execute_reply": "2026-06-26T15:19:49.375204Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original volume:   23.63990300000001\n",
+      "Strained volume:   24.356215700803006\n"
+     ]
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Fe\", cubic=True)\n",
+    "strained = stk.common.apply_strain(structure=structure, epsilon=0.01, return_box=True)\n",
+    "\n",
+    "print(\"Original volume:  \", structure.get_volume())\n",
+    "print(\"Strained volume:  \", strained.get_volume())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fc0406f",
+   "metadata": {},
+   "source": [
+    "### Converting to other structure representations\n",
+    "\n",
+    "Several materials-science packages have their own structure classes. `structuretoolkit` provides\n",
+    "light-weight, round-trip converters so you never have to leave the ASE `Atoms` representation for long:\n",
+    "\n",
+    "* `ase_to_pymatgen()` / `pymatgen_to_ase()` / `pymatgen_read_from_file()` &ndash; convert to/from\n",
+    "  `pymatgen.core.Structure`, e.g. to use `pymatgen`'s symmetry or surface generation tools.\n",
+    "* `ase_to_pyscal()` &ndash; convert to a `pyscal3.core.System`, which several of the\n",
+    "  `structuretoolkit.analyse` functions use internally for structural fingerprinting.\n",
+    "* `atoms_to_phonopy()` / `phonopy_to_atoms()` &ndash; convert to/from `phonopy.structure.atoms.PhonopyAtoms`,\n",
+    "  e.g. as input for a phonon calculation with `phonopy`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b8a882f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:49.418552Z",
+     "iopub.status.busy": "2026-06-26T15:19:49.418179Z",
+     "iopub.status.idle": "2026-06-26T15:19:55.770273Z",
+     "shell.execute_reply": "2026-06-26T15:19:55.757392Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Full Formula (Fe2)\n",
+      "Reduced Formula: Fe\n",
+      "abc   :   2.870000   2.870000   2.870000\n",
+      "angles:  90.000000  90.000000  90.000000\n",
+      "pbc   :       True       True       True\n",
+      "Sites (2)\n",
+      "  #  SP      a    b    c    magmom\n",
+      "---  ----  ---  ---  ---  --------\n",
+      "  0  Fe    0    0    0         2.3\n",
+      "  1  Fe    0.5  0.5  0.5       2.3\n",
+      "\n",
+      "Round-tripped through pymatgen: Atoms(symbols='Fe2', pbc=True, cell=[2.87, 2.87, 2.87], initial_magmoms=...)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "pyscal system: <class 'pyscal3.core.System'>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "phonopy atoms: <class 'phonopy.structure.atoms.PhonopyAtoms'>\n",
+      "Round-tripped through phonopy: Atoms(symbols='Fe2', pbc=True, cell=[2.87, 2.87, 2.87])\n"
+     ]
+    }
+   ],
+   "source": [
+    "fe_bulk = bulk(\"Fe\", cubic=True)\n",
+    "\n",
+    "pmg_structure = stk.common.ase_to_pymatgen(structure=fe_bulk)\n",
+    "print(pmg_structure)\n",
+    "\n",
+    "back_to_ase = stk.common.pymatgen_to_ase(structure=pmg_structure)\n",
+    "print(\"\\nRound-tripped through pymatgen:\", back_to_ase)\n",
+    "\n",
+    "pyscal_system = stk.common.ase_to_pyscal(structure=fe_bulk)\n",
+    "print(\"\\npyscal system:\", type(pyscal_system))\n",
+    "\n",
+    "phonopy_atoms = stk.common.atoms_to_phonopy(atom=fe_bulk)\n",
+    "print(\"\\nphonopy atoms:\", type(phonopy_atoms))\n",
+    "print(\"Round-tripped through phonopy:\", stk.common.phonopy_to_atoms(ph_atoms=phonopy_atoms))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61e51781",
+   "metadata": {},
+   "source": [
+    "Finally, `structuretoolkit.common.SymmetryError` is the exception raised by the symmetry-related\n",
+    "functions in `structuretoolkit.analyse` (see below) whenever `spglib` cannot determine the symmetry of a\n",
+    "structure, for example because the cell or the atomic positions are degenerate.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61c063c4",
+   "metadata": {},
+   "source": [
+    "## `structuretoolkit.analyse` &ndash; analysing existing structures\n",
+    "\n",
+    "This is the largest submodule. It contains everything needed to characterise the local and global\n",
+    "geometry of a structure: neighbor lists, symmetry operations, strain, and a number of structural\n",
+    "fingerprints that are commonly used to classify crystal structures or identify defects.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3fe76c4",
+   "metadata": {},
+   "source": [
+    "### Neighbor lists: `get_neighbors()` and `get_neighborhood()`\n",
+    "\n",
+    "`get_neighbors()` is one of the most used functions in the package. It returns a `Neighbors` object\n",
+    "which lazily exposes `distances`, `vecs` (vectors), `indices` and `shells` (the indices of coordination\n",
+    "shells, found by clustering distances) for every atom of the structure, fully periodic-boundary-aware.\n",
+    "You can ask for a fixed number of neighbors (`num_neighbors`) and/or a `cutoff_radius`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6ebf42a6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:55.775421Z",
+     "iopub.status.busy": "2026-06-26T15:19:55.774664Z",
+     "iopub.status.idle": "2026-06-26T15:19:55.838896Z",
+     "shell.execute_reply": "2026-06-26T15:19:55.836347Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Distance to the 8 nearest neighbors of atom 0:\n",
+      " [2.48549291 2.48549291 2.48549291 2.48549291 2.48549291 2.48549291\n",
+      " 2.48549291 2.48549291]\n",
+      "\n",
+      "Coordination shell of each of those neighbors:\n",
+      " [1 1 1 1 1 1 1 1]\n",
+      "\n",
+      "Chemical symbols of the neighbors of atom 0:\n",
+      " ['Fe' 'Fe' 'Fe' 'Fe' 'Fe' 'Fe' 'Fe' 'Fe']\n"
+     ]
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Fe\", cubic=True)  # bcc iron\n",
+    "neigh = stk.analyse.get_neighbors(structure=structure, num_neighbors=8)\n",
+    "\n",
+    "print(\"Distance to the 8 nearest neighbors of atom 0:\\n\", neigh.distances[0])\n",
+    "print(\"\\nCoordination shell of each of those neighbors:\\n\", neigh.shells[0])\n",
+    "print(\"\\nChemical symbols of the neighbors of atom 0:\\n\", neigh.chemical_symbols[0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "041f464c",
+   "metadata": {},
+   "source": [
+    "`get_neighborhood()` answers the same question for arbitrary points in space (not necessarily atomic\n",
+    "positions), which is useful to probe e.g. interstitial sites or grid points.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5861cdd4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:55.858759Z",
+     "iopub.status.busy": "2026-06-26T15:19:55.857600Z",
+     "iopub.status.idle": "2026-06-26T15:19:55.888396Z",
+     "shell.execute_reply": "2026-06-26T15:19:55.882574Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Distances from a random point in the cell to its 4 nearest atoms:\n",
+      " [1.18677451 1.70395382 1.77588186 1.88111735]\n"
+     ]
+    }
+   ],
+   "source": [
+    "random_point_in_cell = np.dot(np.random.random(3), structure.cell)\n",
+    "neigh_point = stk.analyse.get_neighborhood(\n",
+    "    structure=structure, positions=random_point_in_cell, num_neighbors=4\n",
+    ")\n",
+    "print(\"Distances from a random point in the cell to its 4 nearest atoms:\\n\", neigh_point.distances)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c225e0c8",
+   "metadata": {},
+   "source": [
+    "### Minimum-image distances: `get_distances_array()` and `find_mic()`\n",
+    "\n",
+    "`get_distances_array()` returns the full pairwise distance (or vector) matrix between two sets of\n",
+    "positions, automatically applying the minimum image convention for periodic directions.\n",
+    "`find_mic()` is the lower-level function that maps arbitrary displacement vectors onto their periodic\n",
+    "minimum image &ndash; it is what `get_distances_array()` and `get_neighbors()` use internally.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1eb99b86",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:55.897840Z",
+     "iopub.status.busy": "2026-06-26T15:19:55.896673Z",
+     "iopub.status.idle": "2026-06-26T15:19:55.920566Z",
+     "shell.execute_reply": "2026-06-26T15:19:55.915629Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pairwise distance matrix:\n",
+      " [[0.         2.86378246 2.86378246 2.86378246]\n",
+      " [2.86378246 0.         2.86378246 2.86378246]\n",
+      " [2.86378246 2.86378246 0.         2.86378246]\n",
+      " [2.86378246 2.86378246 2.86378246 0.        ]]\n",
+      "\n",
+      "Displacement folded back via the minimum image convention: 2.8637824638055176\n"
+     ]
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Al\", cubic=True)\n",
+    "distance_matrix = stk.analyse.get_distances_array(structure=structure)\n",
+    "print(\"Pairwise distance matrix:\\n\", distance_matrix)\n",
+    "\n",
+    "displacement = structure.positions[0] - structure.positions[1] + 10 * structure.cell[0]\n",
+    "mic_distance = stk.analyse.find_mic(structure=structure, v=displacement, vectors=False)\n",
+    "print(\"\\nDisplacement folded back via the minimum image convention:\", mic_distance)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75d1b364",
+   "metadata": {},
+   "source": [
+    "### Box symmetry\n",
+    "\n",
+    "`get_symmetry()` wraps [`spglib`](https://spglib.readthedocs.io/) and returns a `Symmetry` object with\n",
+    "all rotation/translation pairs that leave the structure invariant. It is the basis for several\n",
+    "convenience functions:\n",
+    "\n",
+    "* `get_spacegroup()` &ndash; the international space-group symbol/number.\n",
+    "* `get_symmetry_dataset()` &ndash; the full `spglib` symmetry dataset (Wyckoff positions, point group, ...).\n",
+    "* `get_primitive_cell()` &ndash; reduce a (super)cell to its primitive cell.\n",
+    "* `symmetrize_vectors()` / `group_points_by_symmetry()` / `get_equivalent_points()` &ndash; use the box\n",
+    "  symmetry to symmetrize per-atom vectors, or to find groups of geometrically equivalent points.\n",
+    "* `get_ir_reciprocal_mesh()` &ndash; the irreducible set of points of a reciprocal-space mesh (e.g. for a\n",
+    "  DFT k-point grid).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "40ddc87b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:55.928409Z",
+     "iopub.status.busy": "2026-06-26T15:19:55.927881Z",
+     "iopub.status.idle": "2026-06-26T15:19:56.252136Z",
+     "shell.execute_reply": "2026-06-26T15:19:56.249754Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of symmetry operations: 1536\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Space group: {'InternationalTableSymbol': 'Fm-3m', 'Number': 225}\n",
+      "\n",
+      "Atoms in the supercell vs. its primitive cell: 32 -> 1\n",
+      "\n",
+      "Norm of a random vector field before/after symmetrization:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5.657155919698908 -> 3.8955176014220065e-17\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Irreducible points of a 4x4x4 k-point mesh: 10 out of 64\n"
+     ]
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Al\", cubic=True).repeat(2)\n",
+    "\n",
+    "sym = stk.analyse.get_symmetry(structure=structure)\n",
+    "print(\"Number of symmetry operations:\", len(sym.rotations))\n",
+    "print(\"Space group:\", stk.analyse.get_spacegroup(structure=structure))\n",
+    "\n",
+    "primitive = stk.analyse.get_primitive_cell(structure=structure)\n",
+    "print(\"\\nAtoms in the supercell vs. its primitive cell:\", len(structure), \"->\", len(primitive))\n",
+    "\n",
+    "# Forces/displacements on a perfect crystal must symmetrize to (numerically) zero\n",
+    "random_vectors = np.random.random(structure.positions.shape)\n",
+    "print(\"\\nNorm of a random vector field before/after symmetrization:\")\n",
+    "print(np.linalg.norm(random_vectors), \"->\", np.linalg.norm(stk.analyse.symmetrize_vectors(structure, random_vectors)))\n",
+    "\n",
+    "mapping, grid_points = stk.analyse.get_ir_reciprocal_mesh(structure=structure, mesh=[4, 4, 4])\n",
+    "print(\"\\nIrreducible points of a 4x4x4 k-point mesh:\", len(np.unique(mapping)), \"out of\", len(grid_points))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34bc8e45",
+   "metadata": {},
+   "source": [
+    "`get_equivalent_atoms()` answers a related, but independent, question: which *atoms* of the structure\n",
+    "map onto each other under the box symmetry. It is implemented via `phonopy`'s `PhonopyAtoms` and\n",
+    "`spglib`, rather than through the `Symmetry` class above.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3c2abd03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:56.257604Z",
+     "iopub.status.busy": "2026-06-26T15:19:56.256656Z",
+     "iopub.status.idle": "2026-06-26T15:19:56.287444Z",
+     "shell.execute_reply": "2026-06-26T15:19:56.286061Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equivalent-atom labels: [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Al\", cubic=True).repeat(2)\n",
+    "print(\"Equivalent-atom labels:\", stk.analyse.get_equivalent_atoms(structure=structure))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62b5fff0",
+   "metadata": {},
+   "source": [
+    "### Layers, tessellations and clustering\n",
+    "\n",
+    "* `get_layers()` groups atoms into layers along the cell directions (or arbitrary `planes`), which is\n",
+    "  useful for analysing slabs, stacking sequences or counting the number of atomic layers.\n",
+    "* `get_voronoi_vertices()`, `get_voronoi_neighbors()` and `get_delaunay_neighbors()` expose the\n",
+    "  Voronoi/Delaunay tessellation of the (periodic) atom positions.\n",
+    "* `get_cluster_positions()` merges positions that lie within a given distance of each other (DBSCAN\n",
+    "  clustering), e.g. to average out thermal noise or symmetric duplicates.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "4648ceaf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:19:56.290703Z",
+     "iopub.status.busy": "2026-06-26T15:19:56.290462Z",
+     "iopub.status.idle": "2026-06-26T15:20:08.035201Z",
+     "shell.execute_reply": "2026-06-26T15:20:08.029003Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of (111)-independent layers along x, y, z: [6 6 6]\n",
+      "\n",
+      "Voronoi vertices of an fcc unit cell (octahedral + tetrahedral sites): 12\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Voronoi neighbor pairs: 846  Delaunay neighbor pairs: 1051\n",
+      "\n",
+      "Duplicated positions clustered back down to: 108 (original count: 108 )\n"
+     ]
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Al\", cubic=True).repeat(3)\n",
+    "\n",
+    "layers = stk.analyse.get_layers(structure=structure)\n",
+    "print(\"Number of (111)-independent layers along x, y, z:\", layers.max(axis=0) + 1)\n",
+    "\n",
+    "voronoi_vertices = stk.analyse.get_voronoi_vertices(structure=bulk(\"Al\", cubic=True))\n",
+    "print(\"\\nVoronoi vertices of an fcc unit cell (octahedral + tetrahedral sites):\", len(voronoi_vertices))\n",
+    "\n",
+    "voronoi_pairs = stk.analyse.get_voronoi_neighbors(structure=structure)\n",
+    "delaunay_pairs = stk.analyse.get_delaunay_neighbors(structure=structure)\n",
+    "print(\"Voronoi neighbor pairs:\", len(voronoi_pairs), \" Delaunay neighbor pairs:\", len(delaunay_pairs))\n",
+    "\n",
+    "doubled_positions = np.append(structure.positions, structure.positions, axis=0)\n",
+    "clustered = stk.analyse.get_cluster_positions(structure=structure, positions=doubled_positions)\n",
+    "print(\"\\nDuplicated positions clustered back down to:\", len(clustered), \"(original count:\", len(structure), \")\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a47b34c",
+   "metadata": {},
+   "source": [
+    "`get_average_of_unique_labels()` is the small helper used internally by `get_layers()` and\n",
+    "`get_cluster_positions()`: given an array of (possibly repeated) integer labels, it returns the average\n",
+    "value of the elements that share a label.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b3b40478",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:08.048348Z",
+     "iopub.status.busy": "2026-06-26T15:20:08.046690Z",
+     "iopub.status.idle": "2026-06-26T15:20:08.066548Z",
+     "shell.execute_reply": "2026-06-26T15:20:08.061813Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1. 1. 3.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "labels = [0, 1, 0, 2]\n",
+    "values = [0, 1, 2, 3]\n",
+    "print(stk.analyse.get_average_of_unique_labels(labels=labels, values=values))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "044a90f4",
+   "metadata": {},
+   "source": [
+    "### Interstitial sites: `get_interstitials()`\n",
+    "\n",
+    "`get_interstitials()` returns an `Interstitials` object which automatically searches for interstitial\n",
+    "sites of a given coordination number, e.g. tetrahedral (`num_neighbors=4`) or octahedral\n",
+    "(`num_neighbors=6`) sites in a bcc lattice. Besides the `positions`, it exposes diagnostic quantities\n",
+    "like `get_distances()`, `get_volumes()` and `get_steinhardt_parameters()` of the candidate sites &ndash;\n",
+    "useful to judge how \"clean\" / symmetric the identified sites are.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "87b2dcd5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:08.086938Z",
+     "iopub.status.busy": "2026-06-26T15:20:08.085286Z",
+     "iopub.status.idle": "2026-06-26T15:20:08.636774Z",
+     "shell.execute_reply": "2026-06-26T15:20:08.629147Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Octahedral interstitial sites in bcc Fe: 6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tetrahedral interstitial sites in bcc Fe: 12\n",
+      "\n",
+      "Distance of the octahedral sites to their nearest neighbor atoms: [1.435 1.435 1.435 1.435 1.435 1.435]\n"
+     ]
+    }
+   ],
+   "source": [
+    "bcc_fe = bulk(\"Fe\", cubic=True)\n",
+    "\n",
+    "octahedral = stk.analyse.get_interstitials(structure=bcc_fe, num_neighbors=6)\n",
+    "tetrahedral = stk.analyse.get_interstitials(structure=bcc_fe, num_neighbors=4)\n",
+    "\n",
+    "print(\"Octahedral interstitial sites in bcc Fe:\", len(octahedral.positions))\n",
+    "print(\"Tetrahedral interstitial sites in bcc Fe:\", len(tetrahedral.positions))\n",
+    "print(\"\\nDistance of the octahedral sites to their nearest neighbor atoms:\", octahedral.get_distances())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44676ea5",
+   "metadata": {},
+   "source": [
+    "### Local strain: `get_strain()`\n",
+    "\n",
+    "`get_strain()` compares a (e.g. deformed, defective, or thermally displaced) structure against an ideal\n",
+    "reference structure of the same crystal type, and returns the Lagrangian strain tensor of every atom\n",
+    "based on its local neighborhood. This is a common way to visualise the strain field around a\n",
+    "dislocation, crack tip or grain boundary.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "234e6d7b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:08.642383Z",
+     "iopub.status.busy": "2026-06-26T15:20:08.641983Z",
+     "iopub.status.idle": "2026-06-26T15:20:08.776229Z",
+     "shell.execute_reply": "2026-06-26T15:20:08.765845Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Strain tensor shape: (2, 3, 3)\n",
+      "Per-atom isotropic strain (trace / 3): [0.0202 0.0202]\n"
+     ]
+    }
+   ],
+   "source": [
+    "reference = bulk(\"Fe\", cubic=True)\n",
+    "deformed = stk.common.apply_strain(structure=reference, epsilon=0.02, return_box=True)\n",
+    "\n",
+    "strain = stk.analyse.get_strain(structure=deformed, ref_structure=reference)\n",
+    "print(\"Strain tensor shape:\", strain.shape)\n",
+    "print(\"Per-atom isotropic strain (trace / 3):\", np.trace(strain, axis1=1, axis2=2) / 3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e7f0f4c",
+   "metadata": {},
+   "source": [
+    "### Structural fingerprints (powered by `pyscal`)\n",
+    "\n",
+    "A group of functions builds on [`pyscal`](https://pyscal.org/) to classify the local crystal structure\n",
+    "around each atom &ndash; very useful to identify the crystal structure of an unknown configuration, or to\n",
+    "spot defects (grain boundaries, stacking faults, melted regions, ...) in an otherwise crystalline\n",
+    "structure:\n",
+    "\n",
+    "* `get_adaptive_cna_descriptors()` &ndash; common neighbor analysis (fcc/hcp/bcc/icosahedral/other).\n",
+    "* `get_centro_symmetry_descriptors()` &ndash; centrosymmetry parameter (large for atoms near a defect).\n",
+    "* `get_diamond_structure_descriptors()` &ndash; identifies cubic/hexagonal diamond environments.\n",
+    "* `get_steinhardt_parameters()` &ndash; rotationally invariant bond-orientational order parameters.\n",
+    "* `get_voronoi_volumes()` &ndash; the Voronoi cell volume of every atom.\n",
+    "* `find_solids()` &ndash; counts how many atoms are \"solid\" vs. \"liquid\"-like, e.g. for melting-point\n",
+    "  calculations.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9305f0b7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:08.787077Z",
+     "iopub.status.busy": "2026-06-26T15:20:08.786317Z",
+     "iopub.status.idle": "2026-06-26T15:20:09.931561Z",
+     "shell.execute_reply": "2026-06-26T15:20:09.928948Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Common neighbor analysis of bcc Fe: {'others': 0, 'fcc': 0, 'hcp': 0, 'bcc': 2, 'ico': 0}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Diamond-structure analysis of Si:   {'others': 0, 'cubic diamond': 8, 'cubic diamond 1NN': 0, 'cubic diamond 2NN': 0, 'hex diamond': 0, 'hex diamond 1NN': 0, 'hex diamond 2NN': 0}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Centrosymmetry parameter of perfect bcc Fe (should be ~0): [2.36658272e-30 0.00000000e+00]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Steinhardt parameters q4, q6 shape: (2, 432)\n",
+      "\n",
+      "Voronoi cell volume per atom: [11.8199515 11.8199515]\n",
+      "Number of solid-like atoms (out of 2 ): 2.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "bcc_fe = bulk(\"Fe\", cubic=True)\n",
+    "diamond_si = bulk(\"Si\", crystalstructure=\"diamond\", a=5.43, cubic=True)\n",
+    "\n",
+    "print(\"Common neighbor analysis of bcc Fe:\", stk.analyse.get_adaptive_cna_descriptors(structure=bcc_fe))\n",
+    "print(\"Diamond-structure analysis of Si:  \", stk.analyse.get_diamond_structure_descriptors(structure=diamond_si))\n",
+    "\n",
+    "centro = stk.analyse.get_centro_symmetry_descriptors(structure=bcc_fe, num_neighbors=8)\n",
+    "print(\"\\nCentrosymmetry parameter of perfect bcc Fe (should be ~0):\", centro)\n",
+    "\n",
+    "q, cluster_id = stk.analyse.get_steinhardt_parameters(structure=bcc_fe.repeat(3))\n",
+    "print(\"\\nSteinhardt parameters q4, q6 shape:\", q.shape)\n",
+    "\n",
+    "print(\"\\nVoronoi cell volume per atom:\", stk.analyse.get_voronoi_volumes(structure=bcc_fe))\n",
+    "print(\"Number of solid-like atoms (out of\", len(bcc_fe), \"):\", stk.analyse.find_solids(structure=bcc_fe))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c287f376",
+   "metadata": {},
+   "source": [
+    "### Machine-learning structure descriptors\n",
+    "\n",
+    "Two further analysis tools generate per-atom descriptor vectors that are commonly used as input\n",
+    "features for machine-learned interatomic potentials:\n",
+    "\n",
+    "* `soap_descriptor_per_atom()` computes the Smooth Overlap of Atomic Positions (SOAP) descriptor via the\n",
+    "  optional [`dscribe`](https://singroup.github.io/dscribe/) dependency (`pip install structuretoolkit[dscribe]`).\n",
+    "* `get_snap_descriptors_per_atom()`, `get_snap_descriptor_derivatives()` and `get_snap_descriptor_names()`\n",
+    "  compute the bispectrum components used by the SNAP machine-learning potential, via an embedded\n",
+    "  [LAMMPS](https://www.lammps.org/) instance.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "b7986dce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:09.938096Z",
+     "iopub.status.busy": "2026-06-26T15:20:09.937607Z",
+     "iopub.status.idle": "2026-06-26T15:20:12.078007Z",
+     "shell.execute_reply": "2026-06-26T15:20:12.075731Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SOAP descriptor shape (n_atoms, n_features): (4, 252)\n"
+     ]
+    }
+   ],
+   "source": [
+    "cu_fcc = bulk(\"Cu\", \"fcc\", a=3.6, cubic=True)\n",
+    "\n",
+    "soap = stk.analyse.soap_descriptor_per_atom(structure=cu_fcc, r_cut=6.0, n_max=8, l_max=6)\n",
+    "print(\"SOAP descriptor shape (n_atoms, n_features):\", soap.shape)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d2a9ae0b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:12.081065Z",
+     "iopub.status.busy": "2026-06-26T15:20:12.080810Z",
+     "iopub.status.idle": "2026-06-26T15:20:13.848141Z",
+     "shell.execute_reply": "2026-06-26T15:20:13.844095Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of SNAP bispectrum components: 30\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Skipping execution - incompatible LAMMPS python module installed: lammps.create_atoms() got an unexpected keyword argument 'atomid'\n"
+     ]
+    }
+   ],
+   "source": [
+    "ni_fcc = bulk(\"Ni\", cubic=True)\n",
+    "\n",
+    "snap_names = stk.analyse.get_snap_descriptor_names(twojmax=6)\n",
+    "print(\"Number of SNAP bispectrum components:\", len(snap_names))\n",
+    "\n",
+    "# The exact keyword arguments accepted by lammps.create_atoms() differ between LAMMPS\n",
+    "# python-module releases, so this call is most reliable when structuretoolkit and your\n",
+    "# LAMMPS installation are from a matching, recent release.\n",
+    "try:\n",
+    "    snap_descriptors = stk.analyse.get_snap_descriptors_per_atom(structure=ni_fcc, atom_types=[\"Ni\"])\n",
+    "    print(\"SNAP descriptor shape (n_atoms, n_components):\", snap_descriptors.shape)\n",
+    "except TypeError as error:\n",
+    "    print(\"Skipping execution - incompatible LAMMPS python module installed:\", error)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d102058",
+   "metadata": {},
+   "source": [
+    "## `structuretoolkit.build` &ndash; constructing new structures\n",
+    "\n",
+    "While `ase.build` already provides bulk crystals, surfaces and molecules, `structuretoolkit.build` adds\n",
+    "generators for several structure types that come up frequently in materials science but are not part of\n",
+    "ASE itself: ordered intermetallic compounds, high-index stepped/kinked surfaces, grain boundaries,\n",
+    "special quasirandom structures (SQS) for disordered alloys, regular real-space meshes, and a client for\n",
+    "the Materials Project database.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1888e55",
+   "metadata": {},
+   "source": [
+    "### Ordered compound prototypes: `B2()`, `C14()`, `C15()`, `C36()`, `D03()`\n",
+    "\n",
+    "These functions build the unit cells of common binary intermetallic phases directly from two chemical\n",
+    "symbols (optionally a custom lattice constant), instead of having to look up Wyckoff positions and space\n",
+    "groups by hand. The result is, as always, a plain `ase.atoms.Atoms` object.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "9346f2ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:13.857783Z",
+     "iopub.status.busy": "2026-06-26T15:20:13.856947Z",
+     "iopub.status.idle": "2026-06-26T15:20:14.062007Z",
+     "shell.execute_reply": "2026-06-26T15:20:13.987951Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "B2 FeAl:  AlFe cell = [2.87 2.87 2.87]\n",
+      "C15 MgCu2: Cu16Mg8 cell = [7.38598547 7.38598547 7.38598547]\n"
+     ]
+    }
+   ],
+   "source": [
+    "b2 = stk.build.B2(\"Fe\", \"Al\")  # CsCl-type FeAl\n",
+    "c15 = stk.build.C15(\"Mg\", \"Cu\")  # cubic Laves phase MgCu2\n",
+    "\n",
+    "print(\"B2 FeAl: \", b2.get_chemical_formula(), \"cell =\", b2.cell.lengths())\n",
+    "print(\"C15 MgCu2:\", c15.get_chemical_formula(), \"cell =\", c15.cell.lengths())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4d8748d",
+   "metadata": {},
+   "source": [
+    "### High-index stepped & kinked surfaces\n",
+    "\n",
+    "`get_high_index_surface_info()` derives the Miller index of a high-index surface that exposes a given\n",
+    "terrace, step and kink orientation (following the microfacet notation of Van Hove & Somorjai), and\n",
+    "`high_index_surface()` builds the corresponding relaxed slab (using `pymatgen`'s `SpacegroupAnalyzer`\n",
+    "internally to refine the structure).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "60e932ac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:14.073217Z",
+     "iopub.status.busy": "2026-06-26T15:20:14.072918Z",
+     "iopub.status.idle": "2026-06-26T15:20:14.196377Z",
+     "shell.execute_reply": "2026-06-26T15:20:14.190946Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "High-index Miller index for this terrace/step/kink combination: [-9 -3 -5]\n",
+      "Resulting stepped/kinked Ni slab: Atoms(symbols='Ni20', pbc=True, cell=[[5.575095514876862, 0.0, 0.0], [-2.787547757438404, 5.978623880124941, 0.0], [1.607178864057836e-15, 2.522639151650181e-15, 26.24722271232516]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "miller_index, kink_dir, step_dir = stk.build.get_high_index_surface_info(\n",
+    "    element=\"Ni\",\n",
+    "    crystal_structure=\"fcc\",\n",
+    "    lattice_constant=3.526,\n",
+    "    terrace_orientation=[1, 1, 1],\n",
+    "    step_orientation=[1, 1, 0],\n",
+    "    kink_orientation=[1, 0, 1],\n",
+    "    step_down_vector=[1, 1, 0],\n",
+    "    length_step=2,\n",
+    "    length_terrace=3,\n",
+    "    length_kink=1,\n",
+    ")\n",
+    "print(\"High-index Miller index for this terrace/step/kink combination:\", miller_index)\n",
+    "\n",
+    "slab = stk.build.high_index_surface(\n",
+    "    element=\"Ni\",\n",
+    "    crystal_structure=\"fcc\",\n",
+    "    lattice_constant=3.526,\n",
+    "    terrace_orientation=[1, 1, 1],\n",
+    "    step_orientation=[1, 1, 0],\n",
+    "    kink_orientation=[1, 0, 1],\n",
+    "    step_down_vector=[1, 1, 0],\n",
+    "    length_step=2,\n",
+    "    length_terrace=3,\n",
+    "    length_kink=1,\n",
+    "    layers=20,\n",
+    "    vacuum=10,\n",
+    ")\n",
+    "print(\"Resulting stepped/kinked Ni slab:\", slab)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38627a74",
+   "metadata": {},
+   "source": [
+    "### Grain boundaries\n",
+    "\n",
+    "`get_grainboundary_info()` lists the geometrically possible grain boundaries (by CSL sigma value) for a\n",
+    "given rotation axis, using the optional [`aimsgb`](https://aimsgb.readthedocs.io/) dependency\n",
+    "(`pip install structuretoolkit[grainboundary]`). Once you picked a sigma value and plane,\n",
+    "`grainboundary()` builds the actual bicrystal as an `ase.atoms.Atoms` object.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "3e532c0d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:14.215340Z",
+     "iopub.status.busy": "2026-06-26T15:20:14.214994Z",
+     "iopub.status.idle": "2026-06-26T15:20:22.440278Z",
+     "shell.execute_reply": "2026-06-26T15:20:22.435746Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available grain boundaries for the [0 0 1] axis up to sigma=5:\n",
+      "[np.int64(5)]\n",
+      "\n",
+      "Number of atoms in the sigma=5 [0 0 1](1 2 0) grain boundary: 40\n"
+     ]
+    }
+   ],
+   "source": [
+    "gb_options = stk.build.get_grainboundary_info(axis=[0, 0, 1], max_sigma=5)\n",
+    "print(\"Available grain boundaries for the [0 0 1] axis up to sigma=5:\")\n",
+    "print(list(gb_options.keys()))\n",
+    "\n",
+    "al_bulk = bulk(\"Al\", cubic=True)\n",
+    "gb_structure = stk.build.grainboundary(\n",
+    "    axis=[0, 0, 1], sigma=5, plane=[1, 2, 0], initial_struct=al_bulk\n",
+    ")\n",
+    "print(\"\\nNumber of atoms in the sigma=5 [0 0 1](1 2 0) grain boundary:\", len(gb_structure))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "268f626e",
+   "metadata": {},
+   "source": [
+    "### Regular real-space meshes: `create_mesh()`\n",
+    "\n",
+    "`create_mesh()` builds a regular grid of points spanning a cell (either an `Atoms` object or a raw cell)\n",
+    "&ndash; for example to sample a potential energy surface, or as the starting set of candidate positions in\n",
+    "a custom interstitial search.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "4ca42f19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:22.467587Z",
+     "iopub.status.busy": "2026-06-26T15:20:22.459882Z",
+     "iopub.status.idle": "2026-06-26T15:20:22.551619Z",
+     "shell.execute_reply": "2026-06-26T15:20:22.502751Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mesh array shape (3 components, nx, ny, nz): (3, 4, 4, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Al\", cubic=True)\n",
+    "mesh = stk.create_mesh(cell=structure, n_mesh=4)\n",
+    "print(\"Mesh array shape (3 components, nx, ny, nz):\", mesh.shape)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68dae024",
+   "metadata": {},
+   "source": [
+    "### Special quasirandom structures (SQS)\n",
+    "\n",
+    "`sqs_structures()` generates Special Quasirandom Structures &ndash; supercells whose short-range order\n",
+    "parameters best approximate those of a fully random alloy with a given composition &ndash; via the\n",
+    "optional [`sqsgenerator`](https://sqsgenerator.readthedocs.io/) dependency. This is the standard way to\n",
+    "set up a disordered-alloy supercell for DFT calculations. The function returns a `SqsResultPack`; use\n",
+    "`.best()` to get the single best result, which exposes both the resulting `Atoms` object (`.atoms()`)\n",
+    "and its short-range order parameters (`.sro()`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "af05689c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:22.569974Z",
+     "iopub.status.busy": "2026-06-26T15:20:22.567853Z",
+     "iopub.status.idle": "2026-06-26T15:20:24.249252Z",
+     "shell.execute_reply": "2026-06-26T15:20:24.247483Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SQS composition: {'Au': 16, 'Cu': 16}\n",
+      "Short-range order parameter array shape (n_shells, n_species, n_species): (5, 2, 2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "au_bulk = bulk(\"Au\", cubic=True)\n",
+    "\n",
+    "best_sqs = stk.build.sqs_structures(\n",
+    "    structure=au_bulk,\n",
+    "    composition={\"Cu\": 16, \"Au\": 16},\n",
+    "    supercell=(2, 2, 2),\n",
+    ").best()\n",
+    "\n",
+    "sqs_structure = best_sqs.atoms()\n",
+    "print(\"SQS composition:\", stk.common.get_number_species_atoms(sqs_structure))\n",
+    "print(\"Short-range order parameter array shape (n_shells, n_species, n_species):\", best_sqs.sro().shape)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863e1f83",
+   "metadata": {},
+   "source": [
+    "### Materials Project database access\n",
+    "\n",
+    "`materialsproject_search()` and `materialsproject_by_id()` wrap the\n",
+    "[Materials Project](https://materialsproject.org/) REST API (via the optional `mp-api` dependency,\n",
+    "`pip install structuretoolkit[mp-api]`) and directly return `ase.atoms.Atoms` objects. Both functions\n",
+    "need a (free) Materials Project API key, either passed as `api_key=...` or exported as the `MP_API_KEY`\n",
+    "environment variable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "e34a788d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:24.255218Z",
+     "iopub.status.busy": "2026-06-26T15:20:24.254627Z",
+     "iopub.status.idle": "2026-06-26T15:20:24.266469Z",
+     "shell.execute_reply": "2026-06-26T15:20:24.262534Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Set the MP_API_KEY environment variable (or pass api_key=...) to query the Materials Project, e.g.:\n",
+      "\n",
+      "    structures = list(stk.build.materialsproject_search('Fe', is_stable=True))\n",
+      "    fe_ground_state = stk.build.materialsproject_by_id('mp-13')\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "if os.environ.get(\"MP_API_KEY\"):\n",
+    "    hits = list(stk.build.materialsproject_search(\"Fe\", is_stable=True))\n",
+    "    print(\"Stable Fe-containing entries found:\", len(hits))\n",
+    "    fe_ground_state = stk.build.materialsproject_by_id(\"mp-13\")\n",
+    "    print(fe_ground_state)\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Set the MP_API_KEY environment variable (or pass api_key=...) to query the Materials Project,\"\n",
+    "        \" e.g.:\\n\\n\"\n",
+    "        \"    structures = list(stk.build.materialsproject_search('Fe', is_stable=True))\\n\"\n",
+    "        \"    fe_ground_state = stk.build.materialsproject_by_id('mp-13')\"\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cc0b918",
+   "metadata": {},
+   "source": [
+    "## `structuretoolkit.visualize` &ndash; looking at structures\n",
+    "\n",
+    "`plot3d()` renders any `ase.atoms.Atoms` object in 3d. The default `mode=\"NGLview\"` produces an\n",
+    "interactive [`nglview`](https://github.com/nglviewer/nglview) widget &ndash; the nicest choice for\n",
+    "interactive work in a live Jupyter session, so it is what you will want to use day-to-day. For this\n",
+    "notebook we instead use `mode=\"plotly\"` and render the resulting figure to a static PNG (which needs the\n",
+    "optional `kaleido` package, `pip install kaleido`), so the plot is also visible in a statically rendered\n",
+    "copy of this notebook, e.g. on GitHub.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "de55ca21",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:24.270033Z",
+     "iopub.status.busy": "2026-06-26T15:20:24.269815Z",
+     "iopub.status.idle": "2026-06-26T15:20:52.635222Z",
+     "shell.execute_reply": "2026-06-26T15:20:52.632769Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+gAAAMgCAYAAACwGEg9AAAQAElEQVR4AezdCZwU1bn38YdhHxhEQUCMuOaKa9zQGDEqRtSokcT1alRIvPcaFDWJ0VEIKoKiUePKNQm5EEkMKCi+SFDcBWMUF+IKiXHBiKCgyAzDDm//a6i2p6dnppeq6lp+95PTtZ065zzf09zkqaquqdjM/yGAAAIIIIAAAggggAACCCCAQNkFKszX/6NxBBBAAAEEEEAAAQQQQAABBBDIRyDaCXo+EVIHAQQQQAABBBBAAAEEEEAAgQgIkKA3M0kcQgABBBBAAAEEEEAAAQQQQCAoARL0oKQb98MeBBBAAAEEEEAAAQQQQAABBNICJOhpiritEA8CCCCAAAIIIIAAAggggECUBEjQozRbYRorY0EAAQQQQAABBBBAAAEEEPBUgATdU04a80qAdhBAAAEEEEAAAQQQQACBpAmQoCdtxolXAhQEEEAAAQQQQAABBBBAIHQCJOihmxIGFH0BIkAAAQQQQAABBBBAAAEEChcgQS/cjDMQKK8AvSOAAAIIIIAAAggggEAsBUjQYzmtBIVA8QKciQACCCCAAAIIIIAAAuURIEEvjzu9IpBUAeJGAAEEEEAAAQQQQACBJgRI0JuAYTcCCERRgDEjgAACCCCAAAIIIBBdARL06M4dI0cAgaAF6A8BBBBAAAEEEEAAAR8FSNB9xKVpBBBAoBAB6iKAAAIIIIAAAggkW4AEPdnzT/QIIJAcASJFAAEEEEAAAQQQCLkACXrIJ4jhIYAAAtEQYJQIIIAAAggggAACpQqQoJcqyPkIIIAAAv4L0AMCCCCAAAIIIJAAARL0BEwyISKAAAIINC/AUQQQQAABBBBAIAwCJOhhmAXGgAACCCAQZwFiQwABBBBAAAEE8hIgQc+LiUoIIIAAAgiEVYBxIYAAAggggEBcBEjQ4zKTxIEAAggggIAfArSJAAIIIIAAAoEJkKAHRk1HCCCAAAIIIJAtwDYCCCCAAAIIfCVAgv6VBWsIIIAAAgggEC8BokEAAQQQQCBSAiTokZouBosAAggggAAC4RFgJAgggAACCHgrQILurSetIYAAAggggAAC3gjQCgIIIIBA4gRI0BM35QSMAAIIIIAAAgiYYYAAAgggED4BEvTwzQkjQgABBBBAAAEEoi7A+BFAAAEEihAgQS8CjVMQQAABBBBAAAEEyilA3wgggEA8BUjQ4zmvRIUAAggggAACCCBQrADnIYAAAmUSIEEvEzzdIoAAAggggAACCCRTgKgRQACBpgRI0JuSYT8CCCCAAAIIIIAAAtETYMQIIBBhARL0CE8eQ0cAAQQQQAABBBBAIFgBekMAAT8FSND91KVtBBBAAAEEEEAAAQQQyF+AmggkXIAEPeFfAMJHAAEEEEAAAQQQQCApAsSJQNgFSNDDPkOMDwEEEEAAAQQQQAABBKIgwBgRKFmABL1kQhpAAAEEEEAAAQQQQAABBPwWoP0kCJCgJ2GWiREBBBBAAAEEEEAAAQQQaE6AY6EQIEEPxTQwCAQQQAABBBBAAAEEEEAgvgJElp8ACXp+TtRCAAEEEEAAAQQQQAABBBAIp0BsRkWCHpupJBAEEEAAAQQQQAABBBBAAAHvBYJrkQQ9OGt6QgABBBBAAAEEEEAAAQQQQKChQMYWCXoGBqsIIIAAAggggAACCCCAAAIIlEvAjwS9XLHQLwIIIIAAAggggAACCCCAAAKRFYhggh5ZawaOAAIIIIAAAggggAACCCCAQJMCJOjZNGwjgAACCCCAAAIIIIAAAgggUAYBEvSA0ekOAQQQQAABBBBAAAEEEEAAgVwCJOi5VKK7j5EjgAACCCCAAAIIIIAAAghEVIAEPaITV55h0ysCCCCAAAIIIIAAAggggIBfAiTofsnSbuECnIEAAggggAACCCCAAAIIJFiABD3Bk5+00IkXAQQQQAABBBBAAAEEEAizAAl6mGeHsUVJgLEigAACCCCAAAIIIIAAAiUJkKCXxMfJCAQlQD8IIIAAAggggAACCCAQdwES9LjPMPEhkI8AdRBAAAEEEEAAAQQQQKDsAiToZZ8CBoBA/AWIEAEEEEAAAQQQQAABBFoWIEFv2YgaCCAQbgFGhwACCCCAAAIIIIBALARI0GMxjQSBAAL+CdAyAggggAACCCCAAALBCJCgB+NMLwgggEBuAfYigAACCCCAAAIIILBFgAR9CwQLBBBAII4CxIQAAggggAACCCAQHQES9OjMFSNFAAEEwibAeBBAAAEEEEAAAQQ8FCBB9xCTphBAAAEEvBSgLQQQQAABBBBAIFkCJOjJmm+iRQABBBBwBVgigAACCCCAAAIhEyBBD9mEMBwEEEAAgXgIEAUCCCCAAAIIIFCoAAl6oWLURwABBBBAoPwCjAABBBBAAAEEYihAgh7DSSUkBBBAAAEEShPgbAQQQAABBBAohwAJejnU6RMBBBBAAIEkCxA7AggggAACCOQUIEHPycJOBBBAAAEEEIiqAONGAAEEEEAgqgIk6FGdOcaNAAIIIIAAAuUQoE8EEEAAAQR8EyBB942WhhFAAAEEEEAAgUIFqI8AAgggkGQBEvQkzz6xI4AAAggggECyBIgWAQQQQCDUAiTooZ4eBocAAggggAACCERHgJEigAACCJQmQIJemh9nI4AAAggggAACCAQjQC8IIIBA7AVI0GM/xQSIAAIIIIAAAggg0LIANRBAAIHyC5Cgl38OGAECCCCAAAIIIIBA3AWIDwEEEMhDgAQ9DySqIIAAAggggAACCCAQZgHGhgAC8RAgQY/HPBIFAggggAACCCCAAAJ+CdAuAggEJECCHhA03SCAAAIIIIAAAggggEAuAfYhgIArQILuSrBEAAEEEEAAAQQQQACB+AkQEQIREiBBj9BkMVQEEEAAAQQQQAABBBAIlwCjQcBLARJ0LzVpCwEEEEAAAQQQQAABBBDwToCWEiZAgp6wCSdcBBBAAAEEEEAAAQQQQKBegM+wCZCgh21GGA8CCCCAAAIIIIAAAgggEAcBYihYgAS9YDJOQAABBBBAAAEEEEAAAQQQKLdAHPsnQY/jrBITAggggAACCCCAAAIIIIBAKQJlOZcEvSzsdIoAAggggAACCCCAAAIIIJBcgdyRk6DndmEvAggggAACCCCAAAIIIIAAAoEKeJagBzpqOkMAAQQQQAABBBBAAAEEEEAgZgJRSdBjxk44CCCAAAIIIIAAAggggAACCDQUIEF3PPhAAAEEEEAAAQQQQAABBBBAoLwCJOhB+NMHAggggAACCCCAAAIIIIAAAi0IkKC3ABSFw4wRAQQQQAABBBBAAAEEEEAg+gIk6NGfQ78joH0EEEAAAQQQQAABBBBAAIEABEjQA0Cmi+YEOIYAAggggAACCCCAAAIIICABEnQpUOIrQGQIIIAAAggggAACCCCAQEQESNAjMlEMM5wCjAoBBBBAAAEEEEAAAQQQ8EqABN0rSdpBwHsBWkQAAQQQQAABBBBAAIEECZCgJ2iyCRWBhgJsIYAAAggggAACCCCAQJgESNDDNBuMBYE4CRALAggggAACCCCAAAIIFCRAgl4QF5URQCAsAowDAQQQQAABBBBAAIG4CZCgx21GiQcBBLwQoA0EEEAAAQQQQAABBAIXIEEPnJwOEUAAAQQQQAABBBBAAAEEEGgsQILe2IQ9CCCAQLQFGD0CCCCAAAIIIIBAJAVI0CM5bQwaAQQQKJ8APSOAAAIIIIAAAgj4I0CC7o8rrSKAAAIIFCfAWQgggAACCCCAQGIFSNATO/UEjgACCCRRgJgRQAABBBBAAIHwCpCgh3duGBkCCCCAQNQEGC8CCCCAAAIIIFCCAAl6CXicigACCCCAQJAC9IUAAggggAAC8RYgQY/3/BIdAggggAAC+QpQDwEEEEAAAQTKLECCXuYJoHsEEEAAAQSSIUCUCCCAAAIIINCSAAl6S0IcRwABBBBAAIHwCzBCBBBAAAEEYiBAgh6DSSQEBBBAAAEEEPBXgNYRQAABBBAIQoAEPQhl+kAAAQQQQAABBJoW4AgCCCCAAAKOAAm6w8AHAggggAACCCAQVwHiQgABBBCIigAJelRminEigAACCCCAAAJhFGBMCCCAAAKeCZCge0ZJQwgggAACCCCAAAJeC9AeAgggkCQBEvQkzTaxIoAAAggggAACCGQKsI4AAgiESoAEPVTTwWAQQAABBBBAAAEE4iNAJAgggEBhAiTohXlRGwEEEEAAAQQQQACBcAgwCgQQiJ0ACXrsppSAEEAAAQQQQAABBBAoXYAWEEAgeAES9ODN6REBBBBAAAEEEEAAgaQLED8CCOQQIEHPgcIuBBBAAAEEEEAAAQQQiLIAY0cgmgIk6NGcN0aNAAIIIIAAAggggAAC5RKgXwR8EiBB9wmWZhFAAAEEEEAAAQQQQACBYgQ4J7kCJOjJnXsiRwABBBBAAAEEEEAAgeQJEHGIBUjQQzw5DA0BBBBAAAEEEEAAAQQQiJYAoy1FgAS9FD3ORQABBBBAAAEEEEAAAQQQCE4g5j2RoMd8ggkPAQQQQAABBBBAAAEEEEAgP4Fy1yJBL/cM0D8CCCCAAAIIIIAAAggggEASBFqMkQS9RSIqIIAAAggggAACCCCAAAIIIOC/QGkJuv/jowcEEEAAAQQQQAABBBBAAAEEEiEQ6gQ9ETNAkAgggAACCCCAAAIIIIAAAgikBJKcoKfC5z8IIIAAAggggAACCCCAAAIIhEOABN23eaBhBBBAAAEEEEAAAQQQQAABBPIXIEHP3ypcNRkNAggggAACCCCAAAIIIIBArARI0GM1nd4FQ0sIIIAAAggggAACCCCAAALBCpCgB+tNb/UCfCKAAAIIIIAAAggggAACCGQJkKBngbAZBwFiQAABBBBAAAEEEEAAAQSiJ0CCHr05Y8TlFqB/BBBAAAEEEEAAAQQQQMAHARJ0H1BpEoFSBDgXAQQQQAABBBBAAAEEkilAgp7MeSfq5AoQOQIIIIAAAggggAACCIRUgAQ9pBPDsBCIpgCjRgABBBBAAAEEEEAAgWIFSNCLleM8BBAIXoAeEUAAAQQQQAABBBCIsQAJeownl9AQQKAwAWojgAACCCCAAAIIIFBOARL0curTNwIIJEmAWBFAAAEEEEAAAQQQaFaABL1ZHg4igAACURFgnAgggAACCCCAAAJRFyBBj/oMMn4EEEAgCAH6QAABBBBAAAEEEPBdgATdd2I6QAABBBBoSYDjCCCAAAIIIIAAAmYk6HwLEEAAAQTiLkB8CCCAAAIIIIBAJARI0CMxTQwSAQQQQCC8AowMAQQQQAABBBDwRoAE3RtHWkEAAQQQQMAfAVpFAAEEEEAAgcQIkKAnZqoJFAEEEEAAgcYC7EEAAQQQQACB8AiQoIdnLhgJAggggAACcRMgHgQQQAABBBAoQIAEvQAsqiKAAAIIIIBAmAQYCwIIIIAAAvESIEGP13wSDQIIIIAAAgh4JUA7CCCAAAIIyKVL5gAAEABJREFUBCxAgh4wON0hgAACCCCAAAISoCCAAAIIIJAtQIKeLcI2AggggAACCCAQfQEiQAABBBCIoAAJegQnjSEjgAACCCCAAALlFaB3BBBAAAE/BEjQ/VClTQQQQAABBBBAAIHiBTgTAQQQSKgACXpCJ56wEUAAAQQQQACBpAoQNwIIIBBWARL0sM4M40IAAQQQQAABBBCIogBjRgABBIoWIEEvmo4TEUAAAQQQQAABBBAIWoD+EEAgzgIk6HGeXWJDAAEEEEAAAQQQQKAQAeoigEBZBUjQy8pP5wgggAACCCCAAAIIJEeASBFAoHkBEvTmfTiKAAIIIIAAAggggAAC0RBglAhEXoAEPfJTSAAIIIAAAggggAACCCDgvwA9IOC/AAm6/8b0gAACCCCAAAIIIIAAAgg0L8BRBFICJOgpBP6DAAIIIIAAAggggAACCMRZgNiiIUCCHo15YpQIIIAAAggggAACCCCAQFgFGJdHAiToHkHSDAIIIIAAAggggAACCCCAgB8CyWmTBD05c02kCCCAAAIIIIAAAggggAAC2QIh2iZBD9FkMBQEEEAAAQQQQAABBBBAAIF4CRQSDQl6IVrURQABBBBAAAEEEEAAAQQQQMAngSISdJ9GQrMIIIAAAggggAACCCCAAAIIJFggfAl6gieD0BFAAAEEEEAAAQQQQAABBJIrkLgEPblTTeQIIIAAAggggAACCCCAAAJhFiBB93Z2aA0BBBBAAAEEEEAAAQQQQACBogRI0ItiK9dJ9IsAAggggAACCCCAAAIIIBBXARL0uM5sMXFxDgIIIIAAAggggAACCCCAQNkESNDLRp+8jokYAQQQQAABBBBAAAEEEECgaQES9KZtOBItAUaLAAIIIIAAAggggAACCERagAQ90tPH4IMToCcEEEAAAQQQQAABBBBAwF8BEnR/fWkdgfwEqIUAAggggAACCCCAAAKJFyBBT/xXAIAkCBAjAggggAACCCCAAAIIhF+ABD38c8QIEQi7AONDAAEEEEAAAQQQQAABDwRI0D1ApAkEEPBTgLYRQAABBBBAAAEEEEiGAAl6MuaZKBFAoCkB9iOAAAIIIIAAAgggEBIBEvSQTATDQACBeAoQFQIIIIAAAggggAAC+QqQoOcrRT0EEEAgfAKMCAEEEEAAAQQQQCBGAiToMZpMQkEAAQS8FaA1BBBAAAEEEEAAgSAFSNCD1KYvBBBAAIGvBFhDAAEEEEAAAQQQaCBAgt6Agw0EEEAAgbgIEAcCCCCAAAIIIBA1ARL0qM0Y40UAAQQQCIMAY0AAAQQQQAABBDwXIEH3nJQGEUAAAQQQKFWA8xFAAAEEEEAgiQIk6EmcdWJGAAEEEEi2ANEjgAACCCCAQCgFSNBDOS0MCgEEEEAAgegKMHIEEEAAAQQQKE6ABL04N85CAAEEEEAAgfII0CsCCCCAAAKxFSBBj+3UEhgCCCCAAAIIFC7AGQgggAACCJRPgAS9fPb0jAACCCCAAAJJEyBeBBBAAAEEmhEgQW8Gh0MIIIAAAggggECUBBgrAggggEC0BUjQoz1/jB4BBBBAAAEEEAhKgH4QQAABBHwWIEH3GZjmEUAAAQQQQAABBPIRoA4CCCCAAAk63wEEEEAAAQQQQACB+AsQIQIIIBABARL0CEwSQ0QAAQQQQAABBBAItwCjQwABBLwQIEH3QpE2EEAAAQQQQAABBBDwT4CWEUAgIQIk6AmZaMJEAAEEEEAAAQQQQCC3AHsRQCAsAiToYZkJxoEAAggggAACCCCAQBwFiAkBBPIWIEHPm4qKCCCAAAIIIIAAAgggEDYBxoNAnARI0OM0m8SCAAIIIIAAAggggAACXgrQFgKBCpCgB8pNZwgggAACCCCAAAIIIICAK8ASgYYCJOgNPdhCAAEEEEAAAQQQQAABBOIhQBSREyBBj9yUMWAEEEAAAQQQQAABBBBAoPwCjMB7ARJ0701pEQEEEEAAAQQQQAABBBBAoDSBRJ5Ngp7IaSdoBBBAAAEEEEAAAQQQQCDJAuGMnQQ9nPPCqBBAAAEEEEAAAQQQQAABBKIqUOS4SdCLhOM0BBBAAAEEEEAAAQQQQCBsAl+sXGnTn3zSLrvpJjvtkkvs6MGDbb9Bg+yIc86xHwwbZhddd539+ZFH7OOlS8M2dMaTEsg3QU9V5T8IIIAAAggggAACCCCAAAJhFPh0+XK7+s477ahzz7VrUssn/vpX++eHH9ryFSuc4X5ZU2PvffSRzX3lFbtx/Hg74X/+x4Zee60teP995zgf4RAISYIeDgxGgQACCCCAAAIIIIAAAghETeD/pk2zgT/+sT2cunNeyNj/+tprduZPf2rXjRtXyGnU9VEgGQm6j4A0jQACCCCAAAIIIIAAAgiUS+BnY8faHZMmldT9tNmz7ezLLrPPv/yypHY4uXQBEvTSDY0mEEAAAQQQQAABBBBAAIGgBYZdd5099be/Neq2betu1r3z0dZn6/Otb88xtv8Ok2yPXr+yHbcZattWHW8d2n6t0TlvvfuuDa6utppVqxodi9KOPzzwmP32jzPs1Tf+EaVhp8dKgp6mCO0KA0MAAQQQQAABBBBAAAEEGgjcMmGCzXnllQb7tNGt05G2d+/bbKduF1iPLsda5w7/Ya0rOlin9jvZtlVHpZL0H6WO/9p6b3W6qjcoiz75xH5+440N9pVzY8WXtXbhVbely1+efLHF4dz1fw/Z7eOn2d9efafFumGsQIIexlkJdEx0hgACCCCAAAIIIIAAAlESeOWtt2zSww83GHLriirbbdsrbOfuFzoJeYODOTZ6dz3N9ux1k7Vvs12Doy+9/rrzlvcGO8u08ficl+2Zv85Pl9/9aUaZRhJctyTowVknsyeiRgABBBBAAAEEEEAAAU8FxtxzT6P2du95tXWtPKjR/uZ2VLbf2fboNSaV0G/VoNq4P//ZauvqGuwrx8bDjz7foNt/vPdvW/ivjxrsi9sGCXrcZjRh8RAuAggggAACCCCAAAJJEtCb2vXn0jJj3m6r06yy3Y6Zu/Jeb9O6ynbuNrRBff0O/Z7JkxvsC3pj0cdL7bU3/+l0e+bJA5ylPv7yZOPf3Gt/XAoJelxmkjj8EKBNBBBAAAEEEEAAAQRCJaA3rmcOqGPbPrZ918a/J8+s09J618oDbJvKbzeo9sCjjzbYDnrjLxm/N//JeSfb3rvv7Azhwb88Zxs2bnTW4/hBgh7HWSWmiAgwTAQQQAABBBBAAAEE8hdYu26dvb5wYYMTenYZ1GC72I1eW53c4FT1tfD99xvsC2pj8+bN9tCsOU533/7mN6z7NlvZoOP7O9ufr6ixl+c3NHAOxOSDBD0mE0kYCDQSYAcCCCCAAAIIIIBArAT+vWRJo3g6t/96o33F7Khs18datWrX4NTsR+kbHPRxY/5b79q/P/nM6eGkY77lLI/59le/r5/x+F+dfXH8IEGP46wSEwIBCNAFAggggAACCCCAQLACy774okGHrSuqrEPbXg32lbLRuX3fBqcvW7GiwXZQG3/J+J35kd/6htOt7qLrbro2pj861+pWr9Fq7AoJeuymlIAQiIUAQSCAAAIIIIAAAghkCWQnzNkJdVb1gjc7t/+PBucsz7og0OCgTxtr16236Vve3n7ysYdZZccO6Z7cu+na8fRf52sRu0KCHrspJSAEEGhZgBoIIIAAAggggED0BFq1auXroFtZw/Rw0+bNFvT/Pf/SG+m74yd859AG3bt307Xz4dRddC3jVhrOQNyiIx4EEECgHAL0iQACCCCAAAII+CDQbautGrS6et0HDbZL3ajLaq97166lNlnw+f9v9l/T5+zQu4d9snR5uny5cpUdetBezvHn571pny4rzyP4zgB8+iBB9wmWZhFAAAG/BGgXAQQQQAABBJIp0K1r1waBr9v4mW3YtKrBvlI26tY1fGt79222KaW5gs9d8WWtPf7cy+nzjj/7cvvOGT9vUF54+a308UeffjG9HpcVEvS4zCRxIIAAAt4I0AoCCCCAAAIIhFRgtx13tPbtGr5pPfuud7FD37BxlSnhzzx//z32yNz0ff3xOV8l5/l05v4ptnzqRqUOCXpUZopxIoAAArEQIAgEEEAAAQQQKEXgqEMOaXD6J18+2GC72I1Pvpze4NRdd9jBttt22wb7/N548C9znC6+tt229vjkm5ssp3/vKKfeP977ty3810fOelw+SNDjMpPEgQACCCBghgECCCCAAAIxFzjrxBMbRFiz5nVbuvIvDfYVulGz5h1bWtMwQT/9u98ttJmS6i/6eKm9/va/nDZOPq6/9e7Vvcny/dRxp2LqY+YTL6Q+4/MfEvT4zCWRIIAAAgj4LEDzCCCAAAIIlFtg3913t29+4xsNhvHRFxOsbt2iBvvy3dBv2P/12a0Nquu37mccf3yDfX5vzHzyb+kujjvq4PR6rpV99tjFem67tXNIj7lv2LjRWY/DBwl6HGaRGBBAAAEE4iBADAgggAACCOQlMPSssxrVW7j0avuibl6j/c3tWLXuPXtncbVt2NTwbeg/+c//bO40z49t3rzZps+a67S7x9d3tF36bOesN/XRqlUrO/WEI5zDn6+osXmvLXDW4/BBgh6HWSQGBBBAAAEEWhSgAgIIIIBAXAR0F/2c732vQTgbN9Xavz67yd777Ne2YWNNg2O5Nv79xR/tnU+usLUblzQ43G/vve3UY49tsM/vjXf++aH9+5PPnG6+N/BbzrKlj2OP7JeuMjvjze/uzlQO765GakmCHqnpYrAIIIAAAgiEVIBhIYAAAggEKvDzH/3IvrX//o36/Lzurzb/3z+yBUtG2scrptiXq19P3SFfbTVrF5peKPePpdfbq4vOsSUrH2507o69e9uvr7qq0X6/d+z5HzvZW89MdMq5p+V3cWDXnbZ36uu8q392XnqI82bd4+z/ybknp/dFaYUEPUqzxVgRQAABBBBIqABhI4AAAgg0Fvj1lVfaMd/Kfce5du07qYR8qv3z0+ts/kfn2sIlI1IJ+59t5ZrXbNPmNY0a22PXXW3iDTdY58rKRsfYEZwACXpw1vSEAAIIIIAAAuEUYFQIIIBAJAXat2tnv7r8crvk3HNLGr8eaf/zLbfY1lttVVI7nFy6AAl66Ya0gAACCCCAAAIINCPAIQQQQMBfgSE/+IE9On68nXz00QV1dOj++9sDt99uI37yk4LOo7J/AiTo/tnSMgIIIIAAAggg4L8APSCAAAIpgV7du9u1w4bZ03/4g42+9FL7zre+ZV/fcUfbZstd8a2qqmyXHXawbx90kF1+/vn2yD332P9efbVTJ3U6/wmJQEVIxsEwEEAAAQQQQAABBEIowJAQQCBaAnpM/cQjj7SbL7/cuTv+VCphnz99uj07aZI9eOeddseIEXbWiSfa13r1ilZgCRktCXpCJpowEUAAAQQQQACBEAowJAQQQACBDAES9AwMVhFAAAEEEM4x0RgAABAASURBVEAAAQTiJEAsCCCAQLQESNCjNV+MFgEEEEAAAQQQQCAsAowDAQQQ8FiABN1jUJpDAAEEEEAAAQQQQMALAdpAAIHkCZCgJ2/OiRgBBBBAAAEEEEAAAQQQQCCEAiToIZwUhoQAAggggAACCCCAQLQFGD0CCBQjQIJejBrnIIAAAggggAACCCCAQPkE6BmBmAqQoMd0YgkLAQQQQAABBBBAAAEEihPgLATKJUCCXi55+kUAAQQQQAABBBBAAIEkChAzAk0KkKA3ScMBBBBAAAEEEEAAAQQQQCBqAow3ygIk6FGePcaOAAIIIIAAAggggAACCAQpQF++CpCg+8pL4wgggAACCCCAAAIIIIAAAvkKJL0eCXrSvwHEjwACCCCAAAIIIIAAAggkQyD0UZKgh36KGCACCCCAAAIIIIAAAggggED4BUofIQl66Ya0gAACCCCAAAIIIIAAAggggEDJAs0m6CW3TgMIIIAAAggggAACCCCAAAIIIJCXQDkT9LwGSCUEEEAAAQQQQAABBBBAAAEEkiAQ4wQ9CdNHjAgggAACCCCAAAIIIIAAAnERIEEvdiY5DwEEEEAAAQQQQAABBBBAAAEPBUjQPcT0sinaQgABBBBAAAEEEEAAAQQQSJYACXqy5tuNliUCCCCAAAIIIIAAAggggEDIBEjQQzYh8RgOUSCAAAIIIIAAAggggAACCBQqQIJeqBj1yy/ACBBAAAEEEEAAAQQQQACBGAqQoMdwUgmpNAHORgABBBBAAAEEEEAAAQTKIUCCXg51+kyyALEjgAACCCCAAAIIIIAAAjkFSNBzsrATgagKMG4EEEAAAQQQQAABBBCIqgAJelRnjnEjUA4B+kQAAQQQQAABBBBAAAHfBEjQfaOlYQQQKFSA+ggggAACCCCAAAIIJFmABD3Js0/sCCRLgGgRQAABBBBAAAEEEAi1AAl6qKeHwSGAQHQEGCkCCCCAAAIIIIAAAqUJkKCX5sfZCCCAQDAC9IIAAggggAACCCAQewES9NhPMQEigAACLQtQAwEEEEAAAQQQQKD8AiTo5Z8DRoAAAgjEXYD4EEAAAQQQQAABBPIQIEHPA4kqCCCAAAJhFmBsCCCAAAIIIIBAPARI0OMxj0SBAAIIIOCXAO0igAACCCCAAAIBCZCgBwRNNwgggAACCOQSYB8CCCCAAAIIIOAKkKC7EiwRQAABBBCInwARIYAAAggggECEBEjQIzRZDBUBBBBAAIFwCTAaBBBAAAEEEPBSgATdS03aQgABBBBAAAHvBGgJAQQQQACBhAmQoCdswgkXAQQQQAABBOoF+EQAAQQQQCBsAiToYZsRxoMAAggggAACcRAgBgQQQAABBAoWIEEvmIwTEEAAAQQQQACBcgvQPwIIIIBAHAVI0OM4q8SEAAIIIIAAAgiUIsC5CCCAAAJlESBBLws7nSKAAAIIIIAAAskVIHIEEEAAgdwCJOi5XdiLAAIIIIAAAgggEE0BRo0AAghEVoAEPbJTx8ARQAABBBBAAAEEghegRwQQQMA/ARJ0/2xpGQEEEEAAAQQQQACBwgSojQACiRYgQU/09BM8AggggAACCCCAQJIEiBUBBMItQIIe7vlhdAgggAACCCCAAAIIREWAcSKAQIkCJOglAnI6AggggAACCCCAAAIIBCFAHwjEX4AEPf5zTIQIIIAAAggggAACCCDQkgDHEQiBAAl6CCaBISCAAAIIIIAAAggggEC8BYgOgXwESNDzUaIOAggggAACCCCAAAIIIBBeAUYWEwES9JhMJGEggAACCCCAAAIIIIAAAv4I0GpQAiToQUnTDwIIIIAAAggggAACCCCAQGMB9qQFSNDTFKwggAACCCCAAAIIIIAAAgjETSBK8ZCgR2m2GCsCCCCAAAIIIIAAAggggECYBDwdCwm6p5w0hgACCDQvMPiSG+yYM37eYhk2/PbmG+IoAggggAACCCCAQOwEGifosQuRgBBAIGwCK2vrbNzE6eny8ZJlzQ7xqbmvputqvdnKIT+oWBcvXW4tlQXvLgp5JAwPAQQQQAABBBBAwGuBwBN0rwOgPQQQiJ5Al86V9tCjc+3uVJKuMvjSsaakPVckSlSHjbgjXbcqdW6uelHcN+i4/nbh4EFO0XpmDOeedmzmJusIIIAAAggggAACCRCIW4KegCkjRATiITDxtmqr6tTRCWZx6g667qg7GxkfStqVnLu7lMz226+vuxm55bz5C5w75xq44hhTfb4NTSXoKlqvvugsHaIggAACCCCAAAIIJFSABL2giacyAgh4JbB9r+5WPezsdHOTps42lfSO1MrFqTvnSt5Tqzbo2MOcZFbrUS1Pzn01PXTFn97YsnLOqQOtd8pFm/emPLSkIIAAAggggAACCCRHgAQ9THPNWBBImIAe69ZdcTfssXfdZ/qNtraVrOuOs9aVtF6RkcxrXxSLG09zY++7Wx/nsC5M6AkCZ4MPBBBAAAEEEEAAgUQIkKAnYprrg+QTgTAK6PFuNynV+PR79OmPzjUl69rWY/B6HF6/W9d2lMvHn3yWHr5+W684VfTiO/fCxB5bEnRVVB0tKQgggAACCCCAAALJECBBT8Y8BxElfSBQtMAdoy9OP9qtO8fDx45Pt3XnmEss1+Pg6QoRWqlZtTo9WiXfilNFv7MfeOZl9s0TfmKZj8GnK7OCAAIIIIAAAgggkAgBEvRETHMcgiSGOAsoAc981N2NVfv0MjV3O+5LJfBK3OMeJ/EhgAACCCCAAAII5BYgQc/twt6kCRBv2QX0e/TMR901oKP6H6BF7Iri1IUHPb4fxuAWL19t2aWmbr0zVC2zj3m57XSS+vCyzey2VtSuS/VgVrd2Q6M4s+uWsr1x42ann6VfrPGtn2Ur1zp9rF2/ybc+ZKD21ZH607YfRU7qQ25+tO+2qXlXP/oeuPv8WKoPlZbaVh0KAggggAACrgAJuivBEgEfBWi6ZYFxE6db9t1jvcXd/W12yy1Ep4bi1AvjdMc8OqNmpAgggAACCCCAAAJ+C5Cg+y1M+wj4LxD5HpSs3p1K0N1A3DvL+j26+7I491icltUXnWWzJ99sbz0z0SbeVm16iiBO8RELAggggAACCCCAQGECJOiFeVEbgQQK+Buy7pAPG357uhMlrXoxnLtDbzjX3XV3O8pLPdrujl9vrz/n1IGm399rnx55H1N9vvXu2U2bTnGPORt8IIAAAggggAACCMRegAQ99lNMgAiEV0B/5/viEXeY+6j3oGMPMyWtSlb1gjh35Lq7rrvs7nZUl717dU8PXTGmN7asyKOmtm7LFgsEEEAAAQQQQACBpAmQoCdtxokXgRAJ6M64fo+tISl5vWLY2Vp1iu4wZz7yfdXY8aa77c7BAj7CVDXzjvjL8xc0Gpo83IsVjQ6GYMczzzxjN4y5zm65aYxv5ZprrrFrUsXPPsZef53Tx5jRo3yLQ+MfNepap5+bbxztWz833TDa6WP0ddf61odiUfuaF/WnbT+KnNSH3Pxo321T865+9D1w9/mxVB8qavuvzz8Xgn/BDAEBBBBAIAoCJOhRmCXGiEAMBSZNnW0qCk2/Ob9z9MXWpXOlNtPliovOMiXu2rF4yTLTS+O0HqJS0FAy747rqQD9vv6ddxeZHuMfnroA4XqoUd1hz0zota+cRcm5ko0bUsntrakE3a9y7bXXmopf7avdG1NJrfq4fvR1pm2/ihJN9XPzjWN86+dXY0c7XqOvG+VbH/JR+4pF/WnbjyIn9SE3P9p329S8qx99D9x9fizVh4rbNkl6Of8/GH0jgAAC0REgQY/OXDFSBGIjoDvhd094KB3PhUO+b5m/z3YPKGHXy9OUwGuf7rZnJrHaF+WiWE49f6QNG3GHTX90bjoUXZS4I3XBwiy9q+wrzzz7rD2bKocedrj97PLhvpWrr77aVPzs44orRzh9XDXil77FofGPHFkfy2VX+Of1i+r6WEb8cqSvsah9zYv6U2x+FDmpD7n50b7bpuZd/eh74O7zY6k+VPRv5oXn55hK2f8hMwAEEEAAgdALkKCHfooYIALxE9Cd4b/N/F/n7eV6g7l+d95UlIXUbaqNsOxXnHps373gkGtcOqaLEro4keu4p/uaaKx3t46WXao6tnFqD/zOALtFj2z7VHSXXsXPPvRos/oYk7rr7Gc/1157jV1zzTWmu85+9XPTDfWP61836lpf50XtKxb151csclIfcvOrD7WreVc/+h5o26+iPlT0b0b/ePRvKPvflbZ1jIIAAggggIArQILuSrBEAAEEfBbQUwJ6dN39nbmSdSXtSsrdrnVMj7vrKQN3X1SXjBsBBBBAAAEEEECgMAES9MK8qI0AAggULaA30Sv5VgNKzPVn1fRn5WZPucW0rkfbdUz1Bl86VqtlKYuXr7bsUrN6gzMWLbOPebntdJL6yKPNRmPM95wVtetSPZjVrd1QdBv59LVx42ann6VfrPGtn2Ur1zp9rF2/ybc+FKvaV0fqT9t+FDmpD7n50b7bpuZd/eh74O7zY6k+VPRvxl3m6kfHKAgggAACCLgCJOiuBEsEEEDAZwG9GE5d6I750MGDtOoUPc6uu+nTxo9K/xZfL8XL/F26U5GPAAXoCgEEEEAAAQQQCF6ABD14c3pEAIGECiz454dO5Ntvt22jN9brgBL10dXna9Upeimes8JH/ASICAEEEEAAAQQQyCFAgp4DhV0IIICA1wIra+tMvy9vqV0l6S3V4TgCLQlwHAEEEEAAAQSiKUCCHs15Y9QIIBAxASXeekmchq074029BE5/E111VPQGey0pCIRMgOEggAACCCCAgE8CJOg+wdIsAgggkC1wdP8D0rv0ErjsJF3J+d0THnLq6HfqAzLqOzv5QCARAgSJAAIIIIBAcgVI0JM790SOAAIBC+jFcO5ddL0E7pQf/9KOOePnpmT9lPNH2rARdziPwSs5rx52tnEHPeAJortkCBAlAggggAACIRYgQQ/x5DA0BBCIn8CE26pNiboi02/SFy9dbvqzanrsXfv67dfXJt5+pemt7tqmIIBAtAQYLQIIIIAAAqUIkKCXose5CCCAQIEC+i36hYMH2QuPjLMx1ec3KLMn32wTUwm8e5e9wKapjgAC8RcgQgQQQACBmAuQoMd8ggkPAQTCKaBEXXfJMwuPtIdzrhgVAskRIFIEEEAAgXILkKCXewboHwEEEEAAAQQQSIIAMSKAAAIItChAgt4iERUQQAABBBBAAAEEwi7A+BBAAIE4CJCgx2EWiQEBBBBAAAEEEEDATwHaRgABBAIRIEEPhJlOEEAAAQQQQAABBBBoSoD9CCCAQL0ACXq9A58IIIAAAggggAACCMRTgKgQQCAyAiTokZkqBooAAlEXWFlbZx8vWZZ3iXq8jB8BBBBAIBkCRIkAAt4JkKB7Z0lLCCCAQLMCp/z4lzbwzMvyLi/NX9BsexxEAAEEEEAgAQKEiECiBEg/va+2AAAQAElEQVTQEzXdBIsAAggggAACCCCAAAJfCbCGQLgESNDDNR+MBgEEYiww8fYrbfbkm23q+FE24bbqnGXo4EExFiA0BBBAAAEEEiZAuAgUKECCXiAY1RFAAIFiBbbv1d1U9titjx28X9+cZd6Wx9qrOnW0vql6xfbFeQgggAACCCAQfwEijJ8ACXr85pSIEEAgogJKzlU0/HNOO9a6dK7UKgUBBBBAAAEEECiHAH2WQYAEvQzodIkAAgjkErh74nRnt+6en3PqQGedDwQQQAABBBBAIJ4CRJVLgAQ9lwr7EEAAgYAFpj8617h7HjA63SGAAAIIIIBAfAUiGhkJekQnjmEjgEB8BFbW1pl797x3r+5W7rvnle1bW3Zp27qVA65l9jEvt51OUh9etpndVrs29f/V17qiVaM4s+uWst2qnsw6tGvsWUq7med2aNs6pWWWCsXXWGSljtqn7DL793JdTupDbl62m92WG4u+B9nHvNxWLCptW/i3ozoUBBBAAIHoCfg14vr/leJX67SLAAIIINCiwKSps23xkmVOvQsHDyr7b8+7dm5n2cVNnrTMPubltoOQ+vCyzey2Kju0SfVg1r5t60ZxZtctZbtCWXOqp606tfWtn84d62Npm0qcSxlrS+e22ZJkVlX6F4ucUlwmt5bGU8pxzbv60feglHZaOld9qOjfjLvMdY6OURBAAAEEEHAFtiTo7iZLBBBAAIEgBXT3fNIDjzld6q3tg47r76yX86Nu7QbLLus3bnKGpGX2MS+3nU5SH162md3W2vUbUz2Ybdi4uVGc2XVL2d60abPTz5p1G33rR22rE/VVylhbOldW6kd2LdUt9nicYpGBvFT0b8Zdan920TEKAggggAACrkAwCbrbG0sEEEAAgQYCuntes2q1s6/6orOcZbk/VtSut+yyZl19gq5l9jEvt93YvWwzu63Va+sT9HUbNjaKM7tuKdub6/Nz+3JVY89S2s08t3bNBodsfepiQ+Z+r9c3brnYULN6g29mclIwcvN6/Jntad7Vj74Hmfu9XlcfKvo34y5z9aFjFAQQQAABBFyBWCTobjAsEUAAgSgJfLxkmbl3z/vt19dUojR+xooAAggggAACCCDgrQAJesue1EAAAQR8ERg3cbq5d8/123NfOqFRBBBAAAEEEEAAgcgIkKCXfaoYAAIIJFFAf1JNf1pNsevOuYrWKQgggAACCCCAAALJFSBBj/vcEx8CCIRSwP2zahocd8+lQEEAAQQQQAABBBAgQec7UJIAJyOAQOECunuuojMH9D+A354LgoIAAggggAACCCBgJOh8CcIswNgQiKVA5t3zsLy5PZbQBIUAAggggAACCERMgAQ9YhPGcL0UoC0EghdYWVtnB+/X1/RY+5jq8237Xt2DHwQ9IoAAAggggAACCIRSgAQ9lNPCoGIhQBAI5BDo0rnShg4e5JRBx/XPUYNdCCCAAAIIIIAAAkkVIEFP6swTd+QFCAABBBBAAAEEEEAAAQTiJUCCHq/5JBoEvBKgHQTs9YVv258enmo33nOvPffiO47I7GffsRE3PWh33zvNpj8+y5Yu+8zZH4WPx59/1n7z53tt9F0P2E9H/9nOuWSKXTbqQbv5t9Ps91Ommo7X1q2KQiiOu8b72z9PtWGjxttFIyfbRVc92CAezV8kgkkNUt+jSdOn2rV3jbfLbpjsfMcUj/td0/fw9QVvp2ryHwQQQAABBOItQIIe7/klOgRCKsCwwizwwmvznERvwh9a28K/n2mrPv2RbVyzlzPktraXVaw53ZZ+cIa99PwAG379HBt56z32r0UfOMfD9qGEW0n5ZalE/InH9rGP//kjW/HJ6Vbz2am2dfvTrdJOt5VLzrAPF55pOj78+rlOsq6EMWyxaDwa112piyMjx77qjPe9t0+31cvPs811p9k2HRrGo/m7oHqSc5FFDjo/bOW91PdGF4CuvWmhLZh/hn30z/OcudF3bJtUPFrqu/bWayfZhHtb2+g7pjkXUsIWB+NBAAEEEEDAK4EKrxqiHQQQQCA0AgykKIHFn35qQ6+53aY/tKuTuFZ1qE/Km2qsTUUn6931dLPai+ymOxY6d9SbqluO/Ur+rrn5MXvvnROdeNq36dHsMHR8q3Yn2L/eOcluvedVC9sdWz2xcP1tr9qnqYsjPbucYBpvcwFp/npUDrHXXxlgo26b5Nx1b65+0Mcmz5hlN9/1b+cCUPfORzbbvb5rimfdijPsLzN72cQHZllYLzo0GwgHEUAAAQQQaEGABL0FIA4jgAAC2QJx3FZyPvymF2zdF0NbTPxyxa+E8dmnd7HxU6blOhz4vhlPPms3pi4a6A55S4ls9uCUDLbfdILdPf6j0Fx0eGDmcyZfXUDIHm9L24q/zboh9qtxc0LxpIMS62Ej77HX5h1iLSXmuWJTov7OG4eE8qJDrvGyDwEEEEAAgUIESNAL0aIuAggg4L9A4D3UrFpll13/sLVe/92S+lbi9M+3jjLdGS2poRJP1p3zR2atMV00KKUpnT/rsQrTI/+ltFPqubpz/tfne5p8i21LFx10seK39y4s+530qamLDVUVQ4q6EOTG71500OPx7j6WCCCAAAIIxEGABD0Os0gMCCAQSYGPlyyz6Y/OtcGXjm1QJk2d7WM8jZv+3f0zSk7O3VaVOD03p6qsSe19018pOTl341GSPiOV7Ou33+6+IJfq94mnV5eUnGeOV08GXHvbpMxdga7rZwN/f20X0wWDUjtWG23XDXEedy+1Lc5HAAEEEEAgLAIk6GGZCcaBAAKJEhg3cboNPPMyGz52vM2bv6BBWfDuosAsXn7zTXv6uQ4l3c1sMNjUhh5bnjbjo7LcqdWj7TXLjkqNwrv/tNlwlPPWeu9azL8lvS2/S7sT8j8hj5pVFYPL8pSDHm2fMPkVzy42KFRdEHrllZ6pC0Iva5OCAAIIIIBA5AUqIh8BASCAAAIRExh+w+/s7lSC7g57QP8DrPqis5yi9d69uruHfF/+6rdPena3OXOwrTccaX78ma/MPrLXlQA+8fQaTy82uH0sW7K36dF5dzuIpR6t18UG3Sn2sj8ltS+/ttrLJvNq65Enn7OOdnpedQuptHXlwTbraRL0QsyoiwACCCAQXgES9PDODSNDAIEYCigxn/7Y805kSsRnT77Z7hx9sZ1z6kCnaP3CwYOc435/6O65rT3Cl26UBD725HJf2m6qUSWAndoc2dThfPY3WUdPBfzl6VeaPO7HgSfnLPL0bnPmGHUB5fHnn83c5eu6Lp7MfWG1J4+25xqoLqCoj1zH2IcAAggggECUBEjQozRbjBUBBCItsLK2zvRou4JQcj7xtmrbPsC75eo3szw3703fEkD1U7OyU6B/Cuuv8z70LQFUPEuWttKihJL/qUo2P/jAv/50AeXjxXX5D6jEmu8t+tDaWvN/tq+ULirb7WRvLHynlCY4FwEEEEAAgVAIkKCHYhoYBAIIJEEg8+Vv11efX9bkXN7v/qujFr4VJU3vffShb+1nNqyXqW1Ys3fmLs/XlyzxvMkmG1Sy2a1zgU8DNNla7gP//iS4x9yf/tvLvl4Mcr5riz7IHSh7EUAAAQQQiJAACXqEJouhIoBAtAWmz5rjBNB3tz7Wb7++pjvq77y7yF6av8D0RndtOxUC+qhZVetrT+3abGur6oK7S+trMKnGO6bu0r4XUBK4qm5Vqkd//1OzsrKgDkqp7PXv6HON5ZMAn3DI1T/7EEAAAQQQ8EKABN0LRdpAAAEEWhBQ8r14af1vsrWut7cfeuJQO/X8kTbk0rHOG921rT+5pmS9heY8Obz8c0+aabKR9m16BP5itSYH48EBJZm1q+NzwWHFilaB/gShhSko+bDiKbkRGkAAAQQQQKDMAiToZZ4AukcAgWQI1NR+ldgtXrLMpj86N2fg+pNrQSbpOQfh4c5Wm9tYz64d8i5u14Wco7rr135p7VN37N3z/Vi2ruhkbVutzzuW1q3rf0PevUv7vM9RLCqtNq8z9edHHJlt9tgqv7lp37b+fy5s3aldwbEong5tW2d268v6+nWtmhlbh/QxdyxdKtum92mMXhc3yM4d2jirWubqwznIBwIIIIAAAlsE6v8bd8sGCwQQQAAB/wWqOnW0Qcf1t6njR5ne4q6iF8b126+v07kS+MGpu+rORoQ/1m741P5j556mRDXf4oabb323XkVFfTLsnu/Hsm7dB7bHrrvkHY87BneMhSxXpe7U646924Yfy65d66xrl855xeP2X0gMmXU//8Jtwb/l7l9vlVcs7ndFy8wxlrSeuhiTfb5t+b9WW76aWmbX0faWaiwQQAABBBBwBEjQHQY+EEAAgeAEzj3tWBtTfb7tsVsf50VxepO7knMl6b23vNVdSbp+n+7nqHbYfkvm4FMnNWvetp36fN2WfrEm7+IOpZBzVLdtuy6mBNo9349lRZtPrXXbLnnHsnHjZmcYy1auzfscxaLSc9vtrWbNW875fn307Lk573GtXb/JGcaK2nV5n6M43NKucqVzvl8fGzatsu7d2uc1tjXrNjrD+HLV+rzquzEUunQ6SX2sWrMh9WmmZa42nIMtfHAYAQQQQCA5AiToyZlrIkUAgQgIfD91Z90d5sJ3F7mrvix329Xft3groe2+dXfbuGlz3sUNtJBzVHfbbtvaDn38fbFaVZdVecehMaVjSSXq2i6kHLLfQbbe/E3Qt+qyKe943Fg2FDCXmfEedehB9kXdS24zni/XbfjM9B3I7LOp9U2bNzv9b04tm6rjxX6nk9RHiiz1aaZlrnadg+X9oHcEEEAAgRAJkKCHaDIYCgIIJENAL4lrKlL3DrqO6y66ln6V7w0Y4GvS1KtXfSLk1/iz2917j46mx+qz93uxrTu039iruxdN5d3GDn1q865baEXdne/3jT0LPa3o+vvuvqe1r/Tvz6DpYsY+u+9R9Pg40U8B2kYAAQQQKESABL0QLeoigAACRQroMXY3+daL4JpqJvNlcm79puqWun/3nXe2ys4fltpMzvOXrpxpZw06MOcxv3Yeuv9Btrz2GV+aX23324lHf9uXtptq9IB9dvTlMXddbKjq/rTt2ze4BF0x7rTjZl8uoOiizKGHbLLOlZ3UDSVpAsSLAAIIxEyABD1mE0o4CCAQXoGDt7wEbsG7i0wl10ifnPtqerd+l57e8GnltJN6eX4XXQnTwf1qbZc+O/k06tzN9uy+re33De+TQN1tHnLmgYEngMccdoTVpS4M5I62+L2rNjxjF557SvENFHnmaSd82za28f4CSkXlTDvzpOOLHBWnIdC8AEcRQACBoAVI0IMWpz8EEEiswNDBg9KxD77kBsu8k/7xkmU2buL09D695V133dMn+LSix9yPP+ZzT1+wtq5ipp1x0nE+jbj5ZgefdpytbzfBszu15brb7EY56mcXeJqk1637wI46YpPpYobbR1BL9Xnu6X3ty3Uz0LbNrgAAEABJREFUPetST2r8Z8BPang2eBpCwAwDBBBAoJEACXojEnYggAAC/ggo4b5wS5Jes2q1Db50rJ1y/khnqfW7Uwm6etaj7ZnJvPb5Wc4//SQbcNQCT5J0JUzluNvs+ugxZyW1XiXpuuNbjrvNbjxKan8x9HBPknQ92VDV/SkbdEz57jbrsfpL/nt3T5J0xaOLDWrT9WKJAAKZAqwjgEAUBUjQozhrjBkBBCIroMS7+qKzrKpTRycGPeo+b/4Cc18IN6D/AaY/t6Zk3qkQ0EepSbqSpTq730ZVH2DlTpi8SNIVj3W+y352wQFluducOe1eJOnLap+xPfZ50X7+38E/2p4Zi9b104dSk3TdhT/08Bd5tF2gFATKJUC/CCDgiwAJui+sNIoAAgg0LXDOqQNt9pRbTIm67qi7Zer4UXbn6Ist6OTcHamS9B+e8bktXnG/6dFud39LSzf5u+ayY8uezLpjdZP0bbZ7pOAXrSl+JX+6E6/k2G2znEuNQ3fS23WdUlA8utCgCycX/GgbG3za8YH/jr4pMzdJ/6yusJ8jKJ6la662qy49wMr5JEBTcbEfAQS8E6AlBJIqQIKe1JknbgQQKKtAl86VpkR96OBB5pY9dutT1jGp8+8eeYiNuepw23WPGfb5mvudZDBXsq5ESYl55daP2PdP3hiq5E9xqChJv+In59qQczda6y4TnMeq9cI3HcsuikeP5+uuueIPY/KnJH3ExafY906qMSXqGq/GnR2LthWn5m+HXZ82JfblfqpBY8ouStJ/NfIHtn+/F533BiieXN81nad4dKFBdX9z/S9DcyFIY6MggEAkBRg0AqEVIEEP7dQwMAQQQKA8AkoEf3zGqXbX9T9wkttvHf4369z1TWcw3Xu+abt/Y7J959g37OrLd7fqYceZ3jbuHAzph5LTqy89J3Xhob8Tzy573m877T7Vvr73A04sbjx6PD9Md82b4jzq0INMifoto/rbcce/6cSy49en2o67T3biOeDQGTbkvI3O/F103imhTmZ1EUVvYL+hOjU/ww+0YwbOMcXSc6cpTiyaGxXFc3MqmVfdplzYjwACCIRHgJEgULwACXrxdpyJAAIIxF5Aye2JRx9h/b6xpxPrPn33tLNPPtVJypXIOzsj8qFkUPEMPfs0GzH0P23Yuac7sUQ5nmO/faQTy+X/c4bpoopi0d3/fXevn6+ITI0zzJ7dtrWzTzrJrvrJmc6fgVMsboliPE5QfCCAAAJ+CNBmrAVI0GM9vQSHAAIIIIAAAggggAACCOQvQM3yCpCgl9ef3hFAAAEEEEAAAQQQQACBpAgQZwsCJOgtAHEYAQQQQAABBBBAAAEEEEAgCgLRHyMJevTnkAgQQCBCAitr6+zjJctaLKoXobAYKgIIIIAAAgggEH+BACIkQQ8AmS4QQAABV+CUH//SBp55WYtlyKVj3VNYIoAAAggggAACCCRAQCGSoEuBggACCIRMYGXNqpCNiOEggAACCCCAAAII+C3gY4Lu99BpHwEEEIiuwID+B9iE26rTZer4UTZ78s3pMu3310U3OEaOAAIIIIAAAgggUJRAdBP0osLlJAQQQCAcAl06V9rB+/VNlz1262Pb9+qeLjoejpEyCgQQQAABBBBAAIGgBEjQm5BmNwIIIIAAAggggAACCCCAAAJBCpCgB6n9VV+sIYAAAggggAACCCCAAAIIINBAgAS9AUdcNogDAQTCLvDS/AU2fOz4dJk0dbbNS+0L+7gZHwIIIIAAAggggIB/AiTo/tnGt2UiQwCBkgUWL1lm0x+dmy5j77rPBl861ikfp46V3EEJDbRrW2HZpXVFK6dFLbOPebntdJL68LLN7LYUQ6oL0zL7mJfb6kOlfQ5Pr/pp27r+v8Y1PV61masdta9Y1F+u417sa9umPpZWqa+aF+011UaFOkgF0yZl11QdL/anunD+07oiFVBqTctc7aYO8R8EEEAAAQTSAvX/bZjeZAWB8gswAgTiLNClqpP17tnN+u7Wx/rt19dZ17Ybs+6in/LjX1o5k/TuXdpbdqls39oZopbZx7zcdjpJfXjZZnZbVZVtUz2YtW/bulGc2XVL2W7duj4x69q5nW/9bNWpPhYlt6WMtaVz1b7Q1F9LdYs9vk1VO3VhFamEttg28jmvQ7vWTj+dO7bxbV40DqeT1If+zaQWpqX2ZxcdoyCAAAIIIOAKkKC7EiyTIkCcCJRVYNr4Ufb4lFtMy4m3VTvr2tZ6717dnbHVrFpt4yZOd9bL8bF2/SbLLhs3bXaGomX2MS+3nU5SH162md3Who31sWiZfczL7VQYzn+8bDO7rfUbNjl9bErNT/YxL7fVvjpSf162m9mW2lYf6itzv9fral/9qD+v285sT32o6N+Mu8w87q7rGAUBBBBAAAFXgATdlWCJgCcCNIJAcQK6m64kvapTR6eBBe8ucpbl+Fi+cq1ll7q1G52haJl9zMttp5PUh5dtZrdVu3p9qgezdRs2Noozu24p2xu3XAhYUbvOt36+rKuPZX2qr1LG2tK5al9o6q+lusUe/7xmnbqwzanrJ8W2kc95a9bXf5dXrdng27xoHE4wqQ/9m0ktTEvtzy46RkEAAQQQQMAVIEF3JVgiEAUBxhhrge1Td9CrOlc6MZYzQXcGwAcCCCCAAAIIIIBA4AIk6IGT0yEC4RVgZAgggAACCCCAAAIIIFA+ARL08tnTMwJJEyDeFgRW1tZZTaqoWuaL47RNQQABBBBAAAEEEIi/AAl6/OeYCBFIiED4w7x74nRTUSKea7QXj7jD9II4HRt0/OFaUBBAAAEEEEAAAQQSJECCnqDJJlQEEChBwINTFy9Z5rydfeAZP7dhqWR87F332aSps2342PF2zJmX2bz5C5xe9Db3c04d6KzzgQACCCCAAAIIIJAcARL05Mw1kSKAQJkF3BfA6S75U3NfdZJzJenTH51rSt41PCXnept7ly0vi9M+CgIIIIAAAggggEAyBEjQkzHPRIkAAiEQGDp4kFVfdJbp7viA/geYfmfuFv2ZtTHV59vjk282vc3d4+HSHAIIIIAAAggggEAEBEjQIzBJDBEBBOIhoLviSs6VpN85+mJ7fMot6aK75oOO6x/RQBk2AggggAACCCCAgBcCJOheKNIGAggggIB/ArSMAAIIIIAAAggkRIAEPSETTZgIIICAFwKr6lZ50Uwo2ljy2We2dNlnForBlDiImlWrnFhqYzI/ikNzo2WJNJyOAAIIIIBApARI0CM1XQwWAQQQCEZAydGfHp5qo+940Ebc9KD9v8fecTp+5vnlNvjSSXbpNZPs7nun2ePPP+vsD/uH4rl94r1OPOf+dKJ997w/2S+ufc+uvWmhXXRVfYwTH5hlry942+tQfGnv9YVv24333GvX3DrVTrngTzbkp086sfx85FwnntF3TLPfT5lq7y36wJf+vW5U36Mb75lq/3PVfXb84N+Z4hh980fO8rJRD9rNv51mk2fMMhJ2r+VpDwEEEEAgbAIk6GGbEcaDAAIIlFFg8aef2l2pxFuJ6+uvDLB1K063ijWnW1WHvZxRVbbbyfpsM8S6VAyxpR+cYX+Z2ctJCJVgORVC9qHEfOSt9zjJ6/JFP3Li6VE5xHp3Pd22rjzYunc+0rbpUB/je++cZBPubZ1K4qeFNlGX809TF0cm/KG1rfr0R7bmi1Qc7U+3nl1OcGLRUvGsW3GG/SsVz413LHTikUPIpsYZji4CKQF/4rF9bOWSM2zjqtOc75fi0PxoWWmnO8f0fRx+/VwSdUeODwQQQACBuApUxDUw4kIAAQQQKEzg5TfftCvGPmEfvXuUk+y1b9OjxQaUuCshfGzWrqY70C2eEGAFJX/Dr59jVnuRE08+XSseJbd3j//IZjwZnqcDdOdYvg893NqqUhdHNM6W4mlT0clJ3BXPdbfOKe6ig/nzf7pgMDJ14URJtxLwfL5rimerdifYa/MOsTF3POg80u/P6GgVAQQQQACB8gmQoJfPnp4RQACB0Aj8acYMu/aWd639xtMsn2Qpe+CVqTvr77xxiF17272heAz57j+k7oK/MsC5U5491ny2e6buSD/79K72wMzn8qnuax0l55df/xuTr+74F9OZLqLoooPuwBdzvpfnKDn//R8/ci6cFPNd0zlt1w0xXXT4V0Qe4ffSj7YQQAABBOItQIIe7/klOgRCLTBp6mwbN3F63uXjJctCHU8pg1Ns0x+daypaL6WtQs/VY+0Pzlzp3G0t9NzM+kqc6j4/0ZQcZ+4Pel2/I3934d5FXWjIHKsuOrz84t6mO/GZ+4NenzLj0dRd88Elx6OLDlOmLbdyJ7X3/HGWrVl5cMmMuujw23sXNncnveQ+aAABBBBAAIGgBUjQgxanPwQQSAsoGb07laDnW4JOXNMD9XllZW2dXTziDhs+drxTgo5z9Lg/W1XbEzyJUkn655+c6PxO2JMGC2xEd5v/NPWj9G/mCzy9UXXF89ycKnvhtXmNjgWxQxcbXprXueTk3B2rfntfzqR2+uOzrGbZAHc4JS9bbzjSeVleyQ0V1QAnIYAAAggg4L0ACbr3prSIAAJ5CvTu1d169+zmlKpOHVs8q6pzZYt1olhBifmCdxeVZeh6tH35J0eYft/r1QDcpFaPMnvVZr7t6G6zkrZ86+dTT3eep834KJ+qntf53X3PlfxkQ/ag2m86oSyP7uv78PSzFaYnE7LHVOy2vrd63D0Mj+4XG0OT53EAAQQQQCCRAiToiZx2gkYgHAJ3jr7YHp9yi1P+NvN/7a1nJqbL1PGjLDNpH9D/ANtjtz7hGLiHoxh713321NxXPWwx/6b0t7P1aHs+LxzLv9X6mlUd9gw8CdTd5vmv7ezpxYb6aMw2rtkr8D8pp0fr9QI1dwxeLt9+q2fgj4brz/J1anOkl2E4bemC0GNPLnfW+chfgJoIIIAAAuEUIEEP57wwKgQSL/DHBx6zmlWrHQfdaR9Tfb6zHqcP/QZfRTH126+vFoGWhe+/b2021//5NK87VtL0wYetvG622fbm/f1t50+nNVupyINVHfayt96u/z4W2UTBp72f8pNjwSfmcUJV6gLKE88/m0dNb6ropweL/93Dl4snGqEuoETlb75rvAkohIgAAgggUKQACXqRcJyGAAL+CShpnf7Y804Huos+8bZq6xKzx9t111x3zxXkhYMH2dBU0XqQ5bHn3vTst9q5xl1X2yPQN7q/9nd//ytt2Rd1ucL0ZZ8eB/9oUWdf2lajSvw/WRrcBZQnnn/OunX2/u65YlHp2G4ne33hO1qlJEKAIBFAAIH4Cvj7v2bi60ZkCCDgk8C8+QvMTVzVRfWws237Xt21Gpui35tfdcPvnHgGHXtYo+R8cUBvq1/wz43OGPz6aN9mW3vvow/9ar5Bu0poN23o0WCf1xtLlnjdYtPtvbHwbeta2a/pCh4cWbMmuAT940/qPHvRXa7Q9Vv05SukAo4AABAASURBVJ+vynWIfQgULsAZCCCAQBkFSNDLiE/XCCDQUEBvL79q7Pj0znNOHWiDjuuf3o7DimIcNuIO5/H9vrv1sStSFyDiEFeuGHRX871FwSToufr3el99PB943WzZ2gvygkMQQf77k2B/ghBETPQRTwGiQgABBJoTIEFvTodjCCAQqID+1Jh791i/ya6+6KxA+/e7M/fPqSlG/a7+jtEXl/XR/eWf+xux7mquql1j3bq0z7u4IyrkHNVt3Wq9ta7w9y3/eiy8rm5F3rG02nKDepuqdnmfo1hUOnVo41L4tly/rpO1a70hr7G1bV0fzFaVbfOqrxgyS7s2/v/PjU0bOuc1tnZtWjumnTsWF0tmXM2tO52kPirb1/enZa76qSr8BwEvBWgLAQQiLuD/f2NGHIjhI4BAMAJ6rF2Pfqs3N3nVepyK++fU3N/Vx+3R/Vxz1btnlbVvW5F3cdso5BzVXbdutW8vIHPHtHHTKmubSjTVXz6loqKVc2oh57jtfvb5MtMFAacBHz/c/lpalhKL2l67tt7Cx1BM3OqrpdJmy8UGLVuqW8pxN9bWGlhqQ8tc7aUO8R8EIiTAUBFAwG8BEnS/hWkfAQRaFJj+6FzTi+FUUcmr/vxa3F4Kp/j0YjjFeOeYSxr9rr62tk6HAi2dO3Xytb+6dR9Yp05b27KVa/Mu7oAKOUd1v1y13j3Vt6Xi2anP1/OOZdOmzc5YPq9Zl/c5ikWlVUV751w/P6q6rLK1G9vkNbb1GzY5Q5GzxldoWVlbf77TiE8f2/bYlFcsa9fXv3uhpm59XvULjdWt74ZZt7a+Py3dY5lLtx5LBBAwMxAQQMBI0PkSIIBAWQX0m+yxd/4pPYYLh3zf9Nvs9I6YrNRkJOB6QdwxZ/zcMov2uaHKQ8d0x93d58dy+96r/Wg23aYS2h2372Pr1m/Ku7gnF3KO6u6xW19bb2+5p/uyrGjzqbVv1zHvWDbX5+em5FZjLKTs+LU+VrPG33h23mlz3rFsudZg6zfmP5eZ8e7Zt6Ot3fCpL/OiRjdsWmW9e1XmFc/GLcFomTlGr9c1LhX14y5z9aFjFAQQCEaAXhCIggAJehRmiTEiEFOBlamkdfClY50XpilEvRRORetxLouXLrfsUrPqq2RZ6zr+0mv+/tmoo77V09ekSQltz+7bBjaVO6USTj8723UXf3/jnjn2fXff01p38C9BV0K7/XZBxrNH6oLD25kherq+et0HtssOO3raJo0hgAACBQpQHQFPBEjQPWGkEQQQKEZAd4j1wjT3XN1lHjdxurlFj4Xr8Xe36G67WzdqywH9D7Ax1ec3KhcOHmQqmW+rV129IO9Kn9/wftDee/uWNCkB3GGH2kCn6Rt7dfftgoOeBtht5+ASWsHttOOWW/Da8Lgsr30m0IR2lz47WfvK9z2O4qvm1mx6yXbpQ4L+lQhrCCAQPwEiSooACXpSZpo4EQiZgJJt9zfZ7tCUiN+dStDdohfHKYl3ixJ3t27UlnpsX0l4dhmaStBVTs74c3JHp5J5PUmgRN3POHv36GF9+y7ypYuV62baheed4kvbTTV66P4H2cY2zzR1uKT9XXu8aIOOOb6kNgo9+bQTvm3LUol0oee1VF+Pmh/cr9b27btnS1U9Pf7dY/r4cgFFPwU494y+1rnS33cqeIpBYwgggEDYBBhPaAQqQjMSBoIAAgggELjAxeedZItX3O9pv0qYvnNUx8ATJiVoxx7dzXS328uAlq6caWcNOtDLJvNqq2f3bW3PvZZ6ntSuq5hpZ5x0nAX9f8ccdoSpby/71ZMaVd2ftkP37+dls7SFAAIIIOCxAM3lL0CCnr8VNRFAwEMB/YmxFx4ZZ7Mn35x30SPiHg4htE3pz8wFNTjdRb/gvO08TdK79Xoz8LvNrpeSwIMOecOzJN2926xHtN0+glwOPu04W99ugmdJui6eDDnzwMAvnrhm1RcdZ3Xm3QUh50mNc4N9UsONhSUCCCCAQGgEYjUQEvRYTSfBIBAtAf0pNSXq+ZZoRRed0X5vwADzIknX3UwlX/911rfLGvyZJx1vXiTpSs6VHJfjbrMLqKcCRv3sAk+SdCXn39j/vcAfbXdj0VJPBfxi6OGeJOl6suHs03Ywtam2KQgggAACCPgjEGyrJOjBetMbAgggkFNAv1GfOn6UTbituix/Zq7UJF3JX++dHzElX2FImEpN0pX87d/vRbt1xM/LdrfZ/aJ4kaSvrZhp3z1hiQ0+Ldjf0bsxZC71/dD3pK7IO+m6cFKzaYKNqj6AR9szYVlHAAEEEIimQNaoSdCzQNhEAAEEyiGgpwn22K2PHbxfX9N6OcagJH3UL75hX2y4q6BHxN3k76LzTgnV3Uwl6f2PeMO+XDfTdHc/H1Mlf0oclfzp/HzOCaKOm6T/x15POz9HKCQe63yX/eyCA0yP/wcx1nz6cJN0jU0Xd/I5R3WW1T5je+zzol13+Q9C9V3T2CgIIIAAAgh4IeB1gu7FmGgDAQQQQKBMAvrTa3eOusCU2Cp5UnKrBGrjplXOiLRUEvtF3UvOY8o9dpwSuuTPGeiWD715fcxV/e3gw56ydl2nmO6Ma/yZRS+VU+K3qcP9tu+BT9k1lx0byuRPSfqPzzjFxlx1uO26xwxbkbqQ0lQ82t+u6/32nWPfMD0ir4R4C0loFhqTxjbk3I224+6T7fM195u+a5lzo3Xt07FOPf7PLvjRNs5TALIITSAMBAEEEEAAAQ8FIpagexg5TSGAAAIINCmgxFbJ05hUcqsEapddlzp1tTwmlfT9dOg2dvPIH1jY7po7g8z6UDKneEZcfIrdMqq/nX7aB3baKQvte9972xTLKacssasv391Gp+7Knn3yqWV/pD1r+I02ldj++IxT7Y7UhZQbRhzkxPL9QQucWNx4FOeIi38QqrvmjQLZskN/7k3x/O/YU+wXw9rYKd//KhbFM+S8jXbX9T+wKy44t6y/n98yXBYIIIAAAgj4KkCCnsnLOgIIIIBAAwElt0qg3LeYa/mdw44wLRtUjMiG4jn8oH6mx/lPOPIoUyyH7n9QKO+Y50Paa9ttG8TixqM48zk/bHX0BMdJRw1w5kWxqOy7+55hGybjQQABBBBAwDcBEnTfaBs3zB4EEEAAAQQQQAABBBBAAAEEmhIgQW9KJnr7GTECCCCAAAIIIIAAAggggECEBUjQIzx5wQ6d3hBAwEuBlbV19vGSZQ2Kl+3TFgIIIIAAAggggED0BEjQozdn8RwxUSGQEIHpj861wZeOtUNPHGoDz7ysQfnmCT+xuydONyXvCeEgTAQQQAABBBBAAIEMARL0DAxW4ytAZAiEQUB3zIePHW/z5i/IOZyaVattXCpBH5JK4HNWYCcCCCCAAAIIIIBArAVI0GM9vQQXkADdIFCQQO9e3W3Qcf1twm3VNnvyzU6pvugsq+rU0WlnwbuLTHfanQ0+EEAAAQQQQAABBBIjQIKemKkm0OgKMPK4CFR1rrQx1efb46mkXMuD9+tr26eSdZVzTh1o1cPOTofa1F32dAVWEEAAAQQQQAABBGInQIIeuyklIAQKFKB6YAJdUgm67pw31eGA/gc0dYj9CCCAAAIIIIAAAgkQIEFPwCQTIgLlFKDv/AUWvrsoXVmPwac3WEEAAQQQQAABBBBIhAAJeiKmmSARiK1AbALTb86HDb/diUfJuR55dzb4QAABBBBAAAEEEEiMAAl6YqaaQBFAoHABf8+YNHW2ffOEn9heRw42vd1db3HXI/ATb6s2PQ7vb+9Nt966opVll9Qu0/9pmX3My231oeJlm9lttWrVSl1YRWqZfczLbaeT1Efr1q0aeXrVT5uK+lgs9X9etZmrHbebCj/NUk6pMJz/5BqDV/sUgzpp1aqVb/OisdqW/6vYMkVaan922VKNBQIIIIAAAo4ACbrDwAcCCCAQvMCTc181JeWZPetFciqZ+4Je77l1B8sunTq0cYahZfYxL7edTlIfXraZ3dZWndqmejDr0K51oziz65ayrcRcHXXv0t63frp2bqcurH3bCt/6kEHbNvX/c2Gbqna+9SMnBSM39elX0byrH30P/OpD7aoPFf2bcZfan110jIIAAggggIArUP/fuO4WSwQQQACBwAT0p9UuHDzI9Dh7v/36Ov3qrvop5480/c10Z0cJH8WeunHjZssumzfXt6Zl9jEvt+t7sUb9e9nHpk31wWjpZbvZbQURi/oMoh9ZqR8t1adfRX2o+NW+2lUM6kNLbftV1IeK/s24y1x96RgFAQQQQAABV4AE3ZVgiQACCAQs0He3PjY0laArUddj7VpqCIuXLLNxE6drtSxl6Yo1ll1q12xwxqLllmON6nix3+kk9eFFW021sbJufaoHszXrN/oSg9uvkjF1tGzlWt/6+WLVOnVha9dv8q0PxbM+ddFGHX1eu863fuSkPuSmPv0qa1Lzrn70PfCrD7WrPlT0b8Zdan920TEKAggggAACrgAJuivBEgEEECizQOaddL00rszDKXP3dI8AAggggAACCCRPgAQ9eXNOxAgggAACCCCAAAIIIIAAAiEUIEEP4aQwJAQQSK5ATW1dcoOPUeSEggACCCCAAAIIFCNAgl6MGucggAACRQg8NfdVmzd/QZNn6gVxC95d5Bx3XxrnbPCBQEMBthBAAAEEEEAgpgIk6DGdWMJCAIHwCTyZStAHXzrWVJSMK2HX29pfSiXt+jvoY++6Lz1ovd09vcEKAoEK0BkCCCCAAAIIlEuABL1c8vSLAAKJE3D/vrnuoisZHzbiDht45mU2JJW0Z74UTsk5d9AT9/VITsBEigACCCCAAAJNCpCgN0nDAQQQQMBbAb2lXUV/Xi1Xy9p/5+iLnT+9lus4+xBAoGUBaiCAAAIIIBBlARL0KM8eY0cAgUgJbN+ru1VfdJZNGz/KXnhknM2efHO6aFv7B/Q/IFIxMVgEEiZAuAgggAACCPgqQILuKy+NI4AAArkFunSuNCXsbtF27prsRQCB5AgQKQIIIIBA0gVI0JP+DSB+BBBAAAEEEEiGAFEigAACCIRegAQ99FPEABFAAIHyCixd9pmpaBTvLfrAVGrrVmkzkuUfH3xgL7/5ps185ml7/PlnIx3Pqro6W/j++/bqW286sbzw2svpuYri5NSsWmWvpGJRHJobLd3vXhTjSdqYiRcBBBBAoHQBEvTSDWkBAQQQiJ2AEqNrb5tk5//sQbv2poU2/++tnBjf+1dP+/W4z+3nI+faBdWT7PdTpjoJrnMwxB9K9kbc9KATz423f2a/unODzXyknz3x2D7peC4b9aBNnjHLakN+8UEJ6/THZ5nGe9GVz9pV1y+2O3/T0Z5+/Js2/aFdnPnSvI2+Y5qpXhTiueveafaT6ml21kWP2y13b7Rp03o58Wip799FVz1oiuf1BW+H+FvG0HwWoHkEEEAgEQIk6ImYZoJEAAEE8hPQ3Vglfvc/UGUbVw6A3CpYAAAQAElEQVSx3l1Pt+6dj7R2bXo4DbSu6GRbVx5sPbucYD0qh9i/3jnJbrxjod31h2mhTGyVoCoeJeIVa0534tH4qzrsZW1SsbRPxaVtxVNpp9vrrwyw4dfPtRlPPuvEG7aPB2Y+5yTgL8w5xDRejVvjr2y3UzoezZfmbd2KM2zus/s4ifwLr80LWyjOnX4l5krAP/3gDNumw+nO90pz48ajpeLRMcUz4d7WduXYSc65oQuIAUVcgOEjgAAC4RAgQQ/HPDAKBBBAoOwC4++fkUrm/u4kfkqS8hmQklwliR/96yi7/PrfhCZx0l1mJX9uIqtEPN94tmp3gj379K6huuigeIaNvMdefnFv54JJvvEowdWFlIl/+tx5OiAfgyDq6ImGW+951Ra/d6ITT7596nvZdt0Qu+7WORbGiw75xkG9BAoQMgIIIJCnAAl6nlBUQwABBLwS+HjJMntq7qs2/dG56TJv/gJbWVvnVRcFt6Pk/NlnD3DuYBZ8cuoEJYzd213uJE5KJlO7yvqfe/44y0n+NK5iBqLE1r3oUO5HxOWpZHbrNhdZsfHoIsrLL+5jEx+YVQyHp+foMfWpD62x9ptOcO76F9O47qhP+vMa0xMSxZzPOQjETYB4EEAgPgIk6PGZSyJBAIGQCyx4d5ENvnSsDTzzMhs24g4bPnZ8ujj7z/i5TZo6O/Ao9MK0h2dtLDr5yxywEif9VricSa0eT6/7/MSikz83HiXDVRWDberM59xdZVnefe80a73hyJL71kWHN/++j/3p4aklt1VsA/peTJj8StEXgjL77d75KHtk1urQPLWROTbWEYiZAOEggECAAhUB9kVXCCCAQKIFlKDrTrmLUNWpo/Xu2c3dtJpVq23sXffZuInT0/v8XtFbs3/12yc9SZjcseq30RMfeNTdDHSpu81PPJ26O9um/jfzpXauJL2cSa0eBa9ZdlTJFxtcByXpTz9bUbakdsqMR62jne4Op+Slfmv/q3FzyhZPyQHQAAIImBkICCCQKUCCnqnBOgIIIOCjwOIly5zWBx3X36aOH2V/m/m/9viUW+yFR8bZ0MGDnGP6uPeBx0yPwWvd7/K7+2dYu42netqNktq33+ppry8M/o3berRdvyH3MiAlta/9Pfj/utTd5odnLjf97trLeJTU3vPH4C+g6NH2l+Z19uxig2uipwueeP5Zd5MlAggg0FCALQQiJhD8/+KIGBDDRQABBLwS+OGpA2325JttTPX5tsdufdLNdulcaRemEnQl7tqpO+kL312kVV+L7p4/8Yw3j7ZnD7R75yPtub+9k73b120lgCs+PcSXPpQE6m62L4030eiUGbOsS7sTmjha2u6li3cO/K7zU3MWefqkhiugC0LluIDi9s8SAQSSLUD0CHgtQILutSjtIYAAAk0IKBHfvlf3Jo6a9duvb/pYEC+M+39PPWU9uviTACqQ+X9vpUVgZc5L73h+t9kdvJLAt95e7W4Gsnz5tdWe3212B64LKEHeddZPD95Z6N/3YeOavcryxIbryRIBBBDwSYBmEyhAgp7ASSdkBBAIp0BNwG9xX/juZt8SQAl3bLeTvbfoA636XvQ4+D/+0dnXft59P7i37MutQ8XBvsbzyVL/EubsgetiQLfOpb/oLrtdd7v+u/ahu8kSAQQQQCAvASqFUYAEPYyzwpgQQCCRAk/OfTUd94D+B6TX/Vp5f1GNX0077bap6GS1q4NJalfV1dn6dZ2cfv36UPu1dav8ar5Bu+999KG1a7Ntg31eb6xYEVyCvuLLVr5eDNJ3bfnnwcyN1/NAewgggEBsBQisKAES9KLYOAkBBBDwVkBvd1dRq3rUXY/Da93PUufzE9u6q7l4yUfWtXPbvIsbbyHnqO5Wndq6p/q21MviPv3s47xjabUl/9XYNMZCSsf2rX2Lw224ZmWnvGNp27o+mM4d2uR9Tma87dr4/z83Pv2sdV5ja9emtUMg48wxer3udJL66NCuPnYtc/WRqsJ/EEAAAQSKEIjrKfX/rRHX6IgLAQQQiICA/vzasOG3OyPVn16rvugsZ93vj9U+J+i6q7niy9VW2b5N3sWNuZBzVHf9+jXWuqLSPd2XZeuKTqZ+1F8+paKilTOODu1a5x2/2277tvVJpNOATx96ImDjhrV5ja2UWBRT6y0Jvk+hOM2uWGF5xdJmy1hkrLH5VZxBpT7atq7/n1pa5uorVYX/IIAAAgiET6BsI6r/b42ydU/HCCCAQLIF9OfUho24w/Tmdklcf+V/Wd+MN7xrX1TLhk2rrKpzB1tRuy7v4sZayDmqu/izFb4+Qq1xrd3waSqerfOOZdOmzTrNvly1Pu9zFIvKe//+xNq36eGc79dHRZtPbePmtnmNbf2GTc4waldvyKu+YsgsK2vqz3ca8eljq6025zW2tes3OiOoW1NcLJlxNbfudJL6WLOuvj8tc9VPVeE/CCCAAAKJE2g6YBL0pm04ggACCPgqoOR88KVjbfGSZU4/unMexG/Pnc5SH0qgUwvf/rN63Qe2Q+8+Vrd2Y97FHUwh56ju2lQC6Xc86zZ8Zl26bJN3LJvr83NTYqYxFlK26drN/I6na1fLO5Yt1xpsTSq5LSQOt+6Xtf7/Prxnj015xbNxSzDrUt8Zd3x+LN3v8vqN9V8ELXP149ZjiQACCCCAgAQ8SdDVEAUBBBBAIH8BPdaemZxfOHiQnXPqwPwb8KBmv/2qPGil6SbqUgn6Ln12bLqCh0f23X1Pa1/p7xvjq7qsss6VnTwcddNN7ZOKZ0XdvKYreHBku171iaMHTbXYxLf69TE9gdBixSIrqO0dv+bvS/WKHBqnIYAAAgggUJBAFBL0ggKiMgIIIBB2ASc5v+SG9J3zMdXn29BUgh70uA/Zv6evSVOQCa3sdtrR34Rz2x616iaQ0rP7tqkLDu/71pfuzm+/XaVv7Wc3rAsoNWvezt7t2bZzMWiHYC4GeTZoGkIAAQQQQCCHAAm65VBhFwIIIOCTwKSps+2U80c6vznXC+GmjR9lg47r71NvzTd70N57m193aXVH86D9OzY/AI+PHrjvjqZEzeNmneZq1rxlxx95kLMe1Mfee3T07TH3letm2ncO+3ZQoVjP1AWH3l/71Lf+evZ+33bps5Nv7dMwAggggAACQQmQoPstTfsIIIDAFgEl52Pvus/Z6t2ru037/XVlfSFc7x497Jv91vhyF73O7rcTjw4uARTqofsfZGsrZmrV06K7zb12eNH27bunp+221NiJRx9hn670Ph5dxPjOUR0De1zfjfOQA7uZLnS4214tl6aMzhp0oFfN0Q4CCCCAAAJlFSBBLyt/6Z3TAgIIREfg7gkPpQfbpXOljZs43YaPHd9kWVlbl67v18qQUweYtX/W0+a/qHvJ/uusbweeACqIs75/gC1ecb9WPSu623zhead41l6+Demu81FHbPL8qYCq7k/ZoGOOz3cYntU75rAjrFefFz29IKQnNQ7uV8vdc89miYYQQAABBMotQIJe7hkId/+MDgEEPBRw/5SamtTv0Kc/OteaKzUBJOi6i35j9XdsbesHNKySi+4277f/+xb03WZ34Ifu38/OPKWbZ0m67viW426zG8/ZJ59qBx3yhmdJui5eXPDD4JNzN54Lzz3F1reb4FmSric1zjjpOLd5lggggAACCERegAQ98lMY5QAYOwLJErhw8CArpFSl7rIHIeRVkq67mW26TLByJ0zfSd2p9SJJX1b7jH1j//fKcrc5c97PPOl4T5L0L9fNdC5e6M58ZvtBrust+KN+dkHJSbq+a0rOf3r+cWV5UiNIM/pCAAEEEEiWAAl6suY7WdESLQIhExiaStALKXoMPqgQMpN03QUvtF/dmT308BdNyZeSsELP97p+KUm6m/xd8KNtbPBp5bvbnGniJum6o5+5P591xbN0zdV21aUHmFzyOcfPOvp+6HtS7J10/YRih12ftl8MPZxH2/2cKNpGAAEEECiLAAl6WdjpNA4CxIBA3ATcJL3nTlNML97KJ1HXC8eU/I256nArx++am5sDJaMX/3dfa9d1ivNysnziyUz+yvWYflMxKUn/7glL7IsNdznxNFUvc7/mcf9+L9pvrv+l8yb1zGPlXHeTdI1Nd/Z1EaGl8aiOXgL4vZNq7KLzTglVPC2NneMIIIAAAgjkK0CCnq8U9RAIVoDeECiLgJL0Swafa7eM6m8HH/aUk9zWbng6/RtoJeR69PvzNfdbpx7/Z8ce/6/QJX+ZcEqyR1x8ig05d6Pte+BTzqPVSloVQ2bR49I9dpxi/zWkQ6iTP71o7c5RFzjx7Lj7ZPusboJlxqF1xbepw/22/df/z5lHJfaZJmFZV5KusY25qr8dc+wb1mvnKfbF2vtNMWQWxdOu6/2mJzR+dsEBJoOwxMA4EEAAAQQQ8FqABN1rUdpDIBICDBKB5gWUPOmOuJLbUdUH2JGHdXNO0PLqy3e3u67/gV1xwbmRSZaUqCsZvKH6HLtpZD8bd8M37NZr9zbFonLzyB84ifm+u+/pxBn2D8Xz4zNOtd/fcp4Ty+3X7ZOORRdXRl/+A/uf/zw3Er/P1ndNTzsMO+9Um3bP2Xbn6H3TsWhuFM+Ii3/gPKHRs/u2YZ8axocAAggggEBJAhUlnc3JCCCAQC4B9sVKQAlUp8pOTkxaRj1J2m7bbU1PCvRKLRWLihNcRD/qY+nhPPKtWDRfEQ3FGbbiURxuiXo8TlB8IIAAAgggkKcACXqeUFRDAIHwCDASBBBAAAEEEEAAAQTiKECCHsdZJSYEEChFgHMRQAABBBBAAAEEECiLAAl6WdjpFAEEkivQMPJJU2fb4EvH2vRH5zY8wBYCCCCAAAIIIIBA4gRI0BM35QSMAAJhEVjw7iK7e8JDNm/+Aqd4Mi4aQQABBBBAAAEEEIisAAl6ZKeOgSOAQBQFPl6yzHTXfPjY8Tb4khusZtXqSIXBYBFAAAEEEEAAAQT8EyBB98+WlhFAAIFGAg8/OtfG3nWf80g7yXkjHnYggAACCCCAAAKJFiBBT/T0EzwCCAQtMKD/ATam+ny7cPAgpwTdf7L7I3oEEEAAAQQQQCDcAiTo4Z4fRocAAjET6LtbHxt0XH8bmkrQVWIWXrLDIXoEEEAAAQQQQKBEARL0EgE5HQEEEEAAgSAE6AMBBBBAAAEE4i9Agh7/OSZCBBBAAAEEWhLgOAIIIIAAAgiEQIAEPQSTwBAQQACBMAn07tbRsktVxzbOELXMPublttNJ6sPLNrPb6tq5XaoHs8r2bRrFmV23lO3WrVs5/fTcuoNv/XTv0t7po33bCt/6kIHaV0fqT9uFl44tjk9O6kNufrTvtql5Vz/6Hrj7/FiqDxX9m3GXufrRMQoCCCCAAAKuAAm6K8ESAQQQQAABBKIpwKgRQAABBBCIiQAJekwmkjAQQAABrwQWL19t2aVm9QaneS2zj3m57XSS+vCyzey2VtSuS/VgtJ1YaAAAEABJREFUVrd2Q6M4s+uWsr1x42ann6VfrPGtn2Ur1zp9rF2/ybc+ZKD21ZH607YfRU7qQ25+tO+2qXlXP/oeuPtaWhZzXH2o6N+Mu8zVjo5REEAAAQQQcAVI0F0JlggggAACCCCAQPAC9IgAAggggEBagAQ9TcEKAggggAACCCAQNwHiQQABBBCIkgAJepRmi7EigAACCCCAAAJhEmAsCCCAAAKeCpCge8pJYwgggAACCCCAAAJeCdAOAgggkDQBEvSkzTjxIoBA2QU+XrLMVN55d1F6LNrOLOkDrCCAAAII+CVAuwgggEDoBEjQQzclDAgBBOIsMHzseBt45mVOOfX8kelQ581f4Oxzj62srUsfYwUBBBBAIIoCjBkBBBAoXIAEvXAzzkAAAQSKFqjqXGm9e3ZrsdSQoBdtzIkIIIBAIgQIEgEEYilAgh7LaSUoBBAIq0D1RWfZ41NuabFs36t7WENgXAgggAACCRAgRAQQKI8ACXp53OkVAQQQQAABBBBAAIGkChA3Agg0IUCC3gQMuxFAAAEEEEAAAQQQQCCKAowZgegKkKBHd+4YOQIIIIAAAggggAACCAQtQH8I+ChAgu4jLk0jgAACURd4feHb9sJrL9sbC952Qpn397dt+uOznH1Ll33m7IvKR23dKlM8jz73jN0zebL96rf32+0T703Ho+NRiUXjlP/f33nb/jRjhv3u/ik28YFZ9vspU+3x55+19xZ9YFGLZ8lnn9rLb75p9z0yw4nj7nun2W/+fG9k49EcURBAAIFiBDgn2QIk6Mmef6JHAAEEGgko8VPietmoB23CH1rbtGm9bNnSvZ16tSv2tpeeH+Dsu/amhTb6jmlOAhXmZFBJ+V2pZO/nI+c68cycuZe9/MIp9tG7p9nyRT9y4rn/gSrTccXz+paLEU7AIfxQAn7tbZNM/r/9v1b2+OzDbf5Lp9p775xkHy480554bB/79bjPbfj1c50LEGGOR98bxaPv2qhffWS33t3ennzi204cSz84wz7+54+ceG6+699WPfoxmzxjVuQuPITwK8SQEEAg2QJEH3IBEvSQTxDDQwABBIIU0J3l4dfPscXvnWiVdrpVddjLKtvt1GAIbSo6Ofu6dz7S1q04wx6btatdOXaSKbFvULHMG0r+dFf5nt9/bp+mkr2eXU5w4mnfpkeDkSkexanjimfCva1t5K33hC4RlO/PRt9if5nZyzauHGLy17g1/syAFN/WlQfbVu1OcC5A3PN/nzuJbWadMKzrwsE1Nz/mJOD6rmnM+q7likexbtPhdHv9lQFOov7E88+GIQTGgAACCCDQSIAdpQqQoJcqyPkIIIBAEQIfL1lmT8191aY/OjddtK+Ipjw5ZfGnn9rQa2635+ccbr27nm5K8vJtWEnV1m0usutunWNKuvI9z896SmaV/L3zxiFOIltIX0p6N6QS4DBddNBd5tt/u8A6b7rCuchQSDxKbl+bd4jd+L/3huaig+6E68KBEvNCvmtK3pWoPzyjKpQXHQqZF+oigAACCBQhkIBTSNATMMmEiAAC4RJQUn7Kj39pw0bcYcPHjk+XgWdeZmPvuq8sgx097s9Wt/y8ghLz7IEqcZp433J74bV52YcC3dad81vvedV5AqCQ5C9zkEoEddFB7SjZzzwW9Louekx9aI212XBU0V3L4culZzhPBhTdiEcn6h0GumCgCwfFNqm77WrjgZnPFdsE5yGAAAIIINBIIAw7SNDDMAuMAQEEEiMwaepsJyGvWbXaibl3z26mUtWpo7Ot40En6XrJ2PJPjjAlpc4gSvjo3OYomzFrTVkfd5+aStpabziyhCi+OrX9phNMv/dW0v/V3uDW1O/v7nvOenY5oeRONb9t1w0xPfZfcmNFNqCLHU8/W1HShSC3a110eG5OZ+clf+4+lggggAACCIRYIK+hkaDnxUQlBBBAoHSBlbV1dveEh5yGlJDPnnyzPT7lFqdM+/111ne3Ps4xJekvzV/grPv9oUfbH5y5suDHppsbl+703jb+0eaq+HZMd5tfeaWnJxcb3EFWVQw2Jf3udpDLR558znkSwKs+ldS++fd9TG/m96rNQtq554+znN/GF3JOc3V1J/2RWavLekGoufFxDAEEEEAAgUIFKgo9IV2fFQQQQACBggQefnSuuXfOzzntWNu+V/f0+Vq/Y/TF6W0l6ekNH1f0aHtV29LvzmYPcc3Kg523u2fv93Nbd5snTH7FlLR52Y+S2pfmVQWeBOpPpXl1tznTQ+8MmDZjUeauQNb1aPuKTw/xvK/eXU83HnX3nJUGEUAAAQTKJBDaBL1MHnSLAAII+Caw4N2vkqJzTh3YqB8l6f326+vs1wvknBUfP3T3fPFHe3p6t9kdrl609td5X8Xr7vdz+cTzz1lHO92XLqo67GlPv/CyL2031eiMp7x5tD1X+xvX7BX4XfRnn1/m6ZMamXG98Ubn0LwAL3NcrCOAAAIIIFCoQFIT9EKdqI8AAgiULPDSa+84beg35106Vzrr2R/uY+7a/05GQq9tr8vMZ160rpX9vG423d7ifzf8c2bpAz6tvPlOnS8XGzRc3UV/9/369wZo2++ipwH++Y/OvnVT1WEve/sfH/jWfnbD+umBrTs4e7dn24rnjYX1/748a5SGEEAAAQQQKIMACbov6DSKAAIINBZYvHS5s3P77bZ1lrk+MhP3mtq6XFU82/f2whrfEloNsl2bbU2PaWvd76KE9qNF/iW0Gv+SJfoMpry36ENra3v52lnNSn+9Mgf/9j8/tI7tdsrc5em6Htt/b1FwFxw8HTyNIYAAAgggkCFAgp6BEZlVBooAArEV6J3xu3S/g1z2+eaCu/jk38/aqy9el1dZ+Noku+eu2+yWm8bkXa655hq7JlUKOUd1b0318c+/P5jXuPIdf3a9N158MO84NKZRo651Yrn5xtEFnadzf3PXr21Byi97DF5uP/3oH/Me1+jr6mO56YbCY1E80yf/0V6fd6uv8zPj/ofyimfM6FHOvIy9/rq86mv8xRR9j1VeeP45599Z+zYVVtWxTaPiHOQDAQQQQACBLQIVW5YsEEgLsIIAAv4K6Lfm/vaQX+t1BTyxvd3237ZeqbLk4+fstVSCnk9565Xf2J/+77em5Dnfcu2115pKvvXder9JXQjQBYF8xlVsnXdTFwDc/vJZKkFXLDffOKYgA7U9ffKfnIS22LHmc97Lzz6Y97hGXzfKmZdfjR2d9zmKwy1zHnso7+9NPmPPVUd9uP01t7x+9HVOLDemLjY0V6/UY5p7lReen2NHHHGEDTxmgFVVtm1U8vvXSi0EEEAAgaQIkKAnZabDEycjQQCBkAisLiRB/9oRdsAhv7T9CyzHDfqh/ezy4XmXq6++2lQKOUd1z/7Rf9teB/5PweMrJJ59+/3MBp15dt6xjBxZH8tlV+Qfv2JRUT/qr5DxFVp39/3Psf+56NK84hnxy5HOvPyiekRe9RVDZjn82O/7OjeKfe9DfpDX2K4a8UsnliuuLC6WzLiaW9f3WEV1fp76N3DgwYdZTd36RiUk/++AYSCAAAIIhESABD0kE8EwvBKgHQTCL7Cymd+W1zRzrNyRbbclSVeink9RgnnSGd83JSf5Fj0SrJJvfbfeD3+sBP0C5yJCPmMrps7O+xxXUCxK0BXLZVeMKOg8xfStY461foeO9TWePfsdayOvuT6vsY345dWmWC5PJbUaX6HloCN+4Gssms9jTs7vuzZ8xEgnluqrfplX7IXG6taXl4q2Dzykv9Ws3pCzlPvfNf0jgAACCIRLgAQ9XPPBaMIuwPgQKEGgqlNH5+zFS5Y5y1wfH2ccq2riTe+5zitmX7dtWhVzWt7n1Kx5y/bdfY+865dSsWe3bW3ths9KaaLFc+vWvW+79PHvRWeZA+jRXfF8mrnL8/VevQp/B0Gxg+jQvtgz8z9v662Ciyf/UVETAQQQQACBwgRI0AvzojYCvgrQeLwF+n59RyfABc38+bTMO+h+/1a979f9/a+AdamEWYmmE7TPHz1TCe023f1NaL/Wu5PPUXzV/L6772k1a97+aocPa9v1DC6hPXDfHa1unX9vWV+74VPb8WtN/3UEH/hoEgEEEEAAAV8E/P1fZ74MmUYRQKBIAU4rs0Df3fqkR/DS/AXp9cyVJ+e84mz226+vZf7JNWenxx/fOnDnVBL4lsetftVcZedPrXNlcEntzjtu+qpzH9a27VHrQ6u5m9QFh95f8++Cg5LlIBPafXbfw5bVPp07WA/26mLGPqmLGh40RRMIIIAAAgiUVYAEvaz8dI5AnASIpSWBc04dmK5y4133pdfdlXETp1vNqvo3tylBd/f7tTzqkEOsXaU/d2n1ePt3j/nqgoRfMWS2e9ShB6WSwGcyd3m2vnjF/Xbmicd71l4+DR1yYDfTneF86hZaZ23FI/bN/Q8q9LSi6+tCzUH7VxZ9fnMnbti0ynbc+T3TRY3m6nEMAQQQQACBKAiQoEdhlhgjAgiYxcBAj6wPOq6/E4kecx986Vib/uhcpwwfO97uTiXoOqjfqmcm89rnVznskApfksAevV+28753nPXu1rGg4sZZ6Hmq33//PazfgcvdJjxbKkn+/gldbP/d+xQUS+vW9b/x77l1h4LOUywq8rN2z3oWh9vQF3Uv2ZU/Ocb+Y4fueY+rfdv6/7nQvUv7vM9RDJnloh8O9OUCSs36mTb6pz/Me1yV7ds4FF07t8v7nMw48l13Okl9tFQ/VYX/IIAAAgggkBao/2/c9CYrCCCAQDIFgor6iovOMvfu+Lz5C0yJuYoSdY2hd6/uNvH2K31/vF19qVxw5pnWpvNU011IbXtRVqYSpit/8j0vmiq4jSGnDjCvk9p1rafamSek2i14NKWf8KMzdzXdvS+9pfoWNM+HfesjO2jvvet3BPjZu0cPO/HYNZ7+Fl1PavwgdfGkqlOnACOhKwQQQAABBPwTIEH3z5aWEUAAAVcgvdTvyifeVm1DBw9yEvXePbuZin6frrvmOqb19AkBrNwx8nxrVfkHT5J03W0+JZUwKRkLYOiNulC/o36xr2dJ+tKVM+0X/320lSsB1M8QLjhvO8+SdN1t/q/TT2rkFtSO81N9DzhqgWdJup7UOPuk8sUTlBv9IIAAAggkR4AEPTlzTaQIIBAigQtTCbqS8cen3GIq08aPsurU3fXtU3fQCx9maWco+fQiSVcye8QRr9oZZbrb7Cp4lqS3e9Z+dsF2Zbnb7Mai5fcGDLBSk3RdOFlb8YDdOeqYsl1sUCwqXiTpimfn3afZ9Zf9p5qkIIAAAgggEBsBEvTYTCWBIIAAAsULZCbpesN3g5Za2FCypOTvNzd+y5R8tVA9kMNukr6xzV8KfjJA8XTb/g+mO/G6gx3IgFvoxE3SF30+seB4ltU+YwOOWmiTfn2WyaWFrgI5rO/JySd+VNRfEdBPKI477lUbPvTMsl9sCASLTruMI2kAABAASURBVBBAAAEEEiVAgp6o6SZYBBBAoGkBJekTbrzETvjuAlu66m4nedJvlps6Q4msF8lfU+2Xul/J6B2jvmOHHT7Hvlh7vxNPc23qwoTqKfm78fLzQ5PMumNWkj7xlpOtcps/OI+8a7zusVxL/T5bF05G/HQ7c36bn6tSGffpSYtfDGtjVd0fMD190dx3Tcf0crt2XcfZbdd8y3isvYwTR9cIIIAAAr4KVPjaOo0jgAACCEROQMnPjPGXmpInJbcrN91tayvub1Cqtp1qp52y0Mbd8I1QJn8uelWnTvZfp59kE28Z5MSz537TrF3VXxrE0rrTA9b9a/famad95DwCrvjd88O21EWHcddeYlPGDXLGq3Fnz43i0ePfmj/dNS/HC+HyddPYfv3Ls0xPXxwzcI6TrGfH07XnLNsrNW9XXrKVKXYZ5Ns+9RBAAAEEEIiaAAl61GaM8SKAAAIBCSh5UnJ7/52X2qRfn92g/HrEf5ru6EYlWdLTAYrnZ0POtHGjT24Qy2+uP8vG/uLHRcYT0GRkdaN45K9xZ8+N4tHj34o367TQbup7pAsjStaz47n5qu/ZL37847K/CyC0eAwMAQQQQCBWAiTosZpOgkEAAQQQiJUAwSCAAAIIIIBAogRI0BM13QSLAAIIIIDAVwKsIYAAAggggEC4BEjQwzUfjAYBBBBAAIG4CBAHAggggAACCBQoQIJeIBjVEUAAAQQQQCAMAowBAQQQQACB+AmQoMdvTokIAQQQQAABBEoV4HwEEEAAAQTKIECCXgZ0ukQAAQQQQACBZAsQPQIIIIAAArkESNBzqbAPAQQQQAABBBCIrgAjRwABBBCIqAAJekQnjmEjgAACCCCAAALlEaBXBBBAAAG/BEjQ/ZKlXQQQQAABBBBAAIHCBTgDAQQQSLAACXqCJ5/QEUAAAQQQQACBpAkQLwIIIBBmARL0MM8OY0MAAQQQQAABBBCIkgBjRQABBEoSIEEviY+TEUAAAQQQQAABBBAISoB+EEAg7gIk6HGfYeJDAAEEEEAAAQQQQCAfAeoggEDZBUjQyz4FDAABBBBAAAEEEEAAgfgLECECCLQsQILeshE1EEAAAQQQQAABBBBAINwCjA6BWAiQoMdiGgkCAQQQQAABBBBAAAEE/BOgZQSCESBBD8aZXhBAAAEEEEAAAQQQQACB3ALsRWCLAAn6FggWCCCAAAIIIIAAAggggEAcBYgpOgIk6NGZK0aKAAIIIIAAAggggAACCIRNgPF4KECC7iEmTSGAAAIIIIAAAggggAACCHgpkKy2SNCTNd9EiwACCCCAAAIIIIAAAggg4AqEbEmCHrIJYTgIIIAAAgg0J7Dg3UU2buJ0p0yaOru5qpE49vGSZZZdVtbWRWLsmYOM4pgzx886AggggIA/AoW2SoJeqBj1EUAAgZgLKFkae9d9NvjSsfbNE35iex05uFE55oyf2/Cx400JYtgSE41J41PRer7TpbiV+E5/dK4pCW7pPNWXkxyemvtqS9XTx+Wlc1XSOwtY0djuTiXoKup/2Ig7TG0W0ESjqjpfbSkWtduogsc7FLv6OubMy2xgjnLoiUNN86exaGwed99kcxqX+lXJt99xqbk45fyRpjHr34v+3cybv6BBH2pX30XV1fcr37YbNMIGAggggEAiBApM0BNhQpAIIIBAIgWUNChpUsKkZEJJRs2q1TktFi9dbko0lNQNTCXrqp+zYtZOJSgqWbub3VRCqnOU5DRbccvBmtTdV41PRePLd2w6XQmhDHSetpsraldFDlWdK5ur2uCYknkZq+jcBgeL2FB7Q1IXU/L1ydXFw6mLEm4suY5rn5JQJa7NFX2HVLe5orl0Y1+cunveVF3Nn+oq8dW8NFUve38+Y8g+J3Nb/aroe5S5P3td/chEY9N3VMf170X/bpSku3OrGBSvvlOqq++XzitlvtQXBQEEEEAgngLhStDjaUxUCCCAQCQELk7diXWTCnfAfXfrYwP6H2CDjuvvlH779TWV3j27uVVMSYmSj+xz0xUyVh6aNceUpBSSnCj50TlKRDOayntVY1MbLZ2wfa/uToyqpySrpTGqjurKQ0Xr+RRZ9k71pbr5mKlerqI5mHhbtVV16ujc8R+cStLziTNXW26sauucUwfmqmIra1aZEtfmSktJrS4CaC7dDvT9Un8XDh5kKupfx+SjY1pXUZI7/IbfabXF8seps52nP9z5afGEjApKujM2m11VLJneGq+KG4MScdXJjNdtcHHqwoTmy3V397NEAAEEEEAgUQk6040AAgggkFtASYSb0CjJmHBbtb31zESbNn6U3Tn6YhtTfb5TlBCqPD7lFnvhkXE2NJVYuQnJ2Dv/5PyWOHcPxe9dnEpmdHZmMqTtloriUKKneoMvucFJYrXeXPlhRnK68N1FTVZVIueO5+jUBYwmKzZx4ODUhQ4dkrna0noxRRcGpv3+OlOcclKcxVzIcBPFfvvvYV06534aoEtVJ2eI6kv9ukXOzoEWPhTn3RMecmrpO6Pvlkr1RWc53yN9l44+/EDnuHx0TN819aed0x973vndvdZbKnJVAqyi9Zbqu8dbusDg1lMsumigbY1v9uSbnX8rGvPs1L8NXXTQMV0c0lJFFyAm3FbtxKrtxanvtduGtikIIIAAAghIgARdCt4UWkEAAQQiK+AmMUq6lGQoQWopGCVySjqUIKqu7qQvbCapVR23KMFx1/NdPjnnlbySbLc9JY5K8JQMamz6rbabiLp1spd77NbHuSOt/c2NMTOR05131c8uSuDdu6jZx04+rn96V2Zb6Z0FrKh/xal43Th157aAJmzBPz90qqstZyXHh/sYv74b6s8tV6QS7BzVG+3SY/Qanw7cOeYS03i1nlncCyR6skD++j6qHyXBqqcLSS3NoVtX9fW9VpKueWjpPNXPt7gXQfTd0vgy3fTvQhcd9KSE254Sdl2AkJ3+zei4jr2U9Vt17aMggAACCCRbgAQ9MvPPQBFAAAH/BD7+5DOn8cykwtmRx4eSEz1urapKqrRsqZx6/shGL57L9TI67VNSpvaU3OkOcSHJp8Y28fYrdbrpjqWStZYSNTcRdU7K42P3VFKfq5qSOCWa7l3jzDoaV+Z2IeuKI7u+2tPd2UHHHuYc0p1bFWejgA+101R19zvS1PGW9rsXIpSYK/HOVV/JrbvfnSeNSUmwu19Jt7uea6nvsO5o66cZ7nHNwyk//qXz84p8v6Puuc0t9V3R+HLV0THtVxKv5FzrbnHHlmsu3TosEUAAAQSSKUCCnsx5bxw1exBAAIEICChJf7KAN6YrJCWEekRf60qIlKTr7ra2s4uSN/3GOnt/c9tuIpldR21pn8aspd9Fye2YK//L+S23+tKFDD014I5D+1oqTbm0dF4hx93EtaVz3IRe9ZQEu0mtkm3ta66ovn6aocTevRigedAj5XqpoS76FOLSVF/bb7dtzkNqe/qsOc6xQccf3uhnAxqfc5APBBBAAAEEsgRI0LNA2PRHgFYRQCDcAu7vi1u6O5krCiWomclUrjrZ+5Q06U5nsSW7vZa21Y8eLVY9J0m/5AbLFauSWtVRaS6Jykwy9ei26meXzGQ3O6nU3fXs+rm2lejpMejMIm/VlbnayTym9YP2q3+Rn+roeD5veHcTTZ2v87KLrNwLF7rgkXk80yJzf1PrGr9KruOaG3d/tr9+fuAey3ep75mSdBWt6zw3Udeb1LPnRccLKZqDXPXlrn50TI+1a5lZ5Jm5zToCCCCAAAKuAAm6K8EyygKMHQEEShRwky4lLLrLmG9zSrT09nc3GXGToJbO1x3tYouS7Zbaz3Vcjxm7v/3VeHUnXUVJueLW75Td2PVYclOPrqtt3a3ONFMb2u8WbWcmYXqBnraVcKsv97F39ZOdiLptaClfJdiZRefrmGLQHfLMY+66+lIdFV0oyNzWvuzimipBlonG6dbRGK4aO97dbPTbcVmkDzazctSWl+mpj6YuaujOtttEduKfve3Wy2ep7+XE26pNxZ23xUuWmeZc8bbkk92H2tM+2SoZ17pbZJcZxw133dfo5YnuHLpjcc9liQACCCCAAAk63wEEWhSgAgLxF1Dy6r5cS8nFN0/4iZO86HfMSjaVULhFSaz2K7EZeOZl6Re36UVYzSWbYVDUGPXosxJjjUeJmWJRoqb4tE/lwiHfb/RYsvZnFveOvPapDXmoHSXN2tZ+9afkV8m0jh964lDHVdvO8dOO1aLJ0tQd2iZPKPKAxujOv0z0GPgxZ/zcVPTbbSWzalqJqYrWCy26A+4+pq7vmDzc75a+U8ekvkvqW+2qj+zEv6m7+6qfb1G7egmiLg5lxquxqLj9t9SevudqS/WuuuF3pjh0IeOddxeZLpK4XvqeaV2G+k4oTvXjftdcD7VDQQABBBBAQAIk6FKgIFBOAfpGIAQCSjgyE1clkEoilHgosVDi6RYlV9qfmcwoEXXvTocgnGaHoKRIL45zE6zMykqolHgrnsz9udbVjuq6x+QhM/eOqhJAXfhQ0bpbz13q7mlL/aiOXv6moqRSRf2qDY1V29lFdbNLrljVRmbR3WV3nJp/PdKuonXVc/vTerFF3xG3D3m53y19p5TIql0dV0xazyyy0IWEo7fcic88Vui62lGirrlRXDpf41ECrfV8imLRufJRHLpYpZcf6q66zpe5/sKB4lEd/ZtRnOpHxxVPS/OvehQEEEAAgWQJkKAna76JNoEChIxAvgJKGGZPucWUtCi5yOc8JYtKBpWs5FNfifELj4wzXRDIp75fdRSrElKNRcmgii5QKKFS/Pn2q7pqJ9tLCaD26y6wYnWTQe1XUX/ap+PN9aXj+g2zis5T0brO0SPf2s4uOp5dNAad01xRHY1JMblv5Vd9WakP2aiO9mUWjUP1VU/rmcey13W+XPS9yT6mbSWzOq562s4suhgiN6+SWtmqTfc7r2Q7s7+W1hVv9bCz03+WL7O+4tBYFYdMs78fil//bjSGzPNYRwABBBBAgASd7wACCJQiwLkxE1DCoKRFSZKS16njR5kSieyi/W89M9GU1CoZzJdBCYv6yLd+MfV+eOpA05/ZuuKis1o8XWNR8qmipEnja/GkrApKvuQlD7e4yZlbVf3IVftV1J97rNClxqiE+OD99yj01Bbru+N8PHWhxo1FCabGrH5zNaBzVF/1tJ6rTuY+taPvjeZI7bou+k49PvnmwC/eaMwagxL1zO+5xpk57lzrmkdduNAFKl04UFFMmXGofX0/FK+K/l0pfu3P1Sb7EEAAAQSSLUCCnuz5J3oEQi7A8MopoARCvxtWAp5dtL+cY2uub41byZWWzdWL6jFdSFBCrEQwqjFo3JojJbi6Y69lub9T+r5kfs81xnyK4lBiriRdRbHkOk/1VNRPruPsQwABBBBAQAIk6FKgIIBAMgWIGgEEEEAAAQQQQACBEAmQoIdoMhgKAgjES4BQFQVVAAAQAElEQVRoEEAAAQQQQAABBBAoRIAEvRAt6iKAAALhEWAkCCCAAAIIIIAAAjETIEGP2YQSDgIIIOCNAK0ggAACCCCAAAIIBC1Agh60OP0hgAACCJhhgAACCCCAAAIIINBIgAS9EQk7EEAAAQSiLsD4EUAAAQQQQACBKAqQoEdx1hgzAggggEA5BegbAQQQQAABBBDwRYAE3RdWGkUAAQQQQKBYAc5DAAEEEEAAgaQKkKAndeaJGwEEEEAgmQJEjQACCCCAAAKhFSBBD+3UMDAEEEAAAQSiJ8CIEUAAAQQQQKB4ARL04u04EwEEEEAAAQSCFaA3BBBAAAEEYi1Agh7r6SU4BBBAAAEEEMhfgJoIIIAAAgiUV4AEvbz+9I4AAggggAACSREgTgQQQAABBFoQIEFvAYjDCCCAAAIIIIBAFAQYIwIIIIBA9AVI0KM/h0SAAAIIIIAAAgj4LUD7CCCAAAIBCJCgB4BMFwgggAACCCCAAALNCXAMAQQQQEACJOhSoCCAAAIIIIAAAgjEV4DIEEAAgYgIkKBHZKIYJgIIIIAAAggggEA4BRgVAggg4JUACbpXkrSDAAIIIIAAAggggID3ArSIAAIJEiBBT9BkEyoCCCCAAAIIIIAAAg0F2EIAgTAJkKCHaTYYCwIIIIAAAggggAACcRIgFgQQKEiABL0gLiojgAACCCCAAAIIIIBAWAQYBwJxEyBBj9uMEg8CCCCAAAIIIIAAAgh4IUAbCAQuQIIeODkdIoAAAggggAACCCCAAAIIINBYgAS9sQl7EEAAAQQQQAABBBBAAIFoCzD6SAqQoEdy2hg0AggggAACCCCAAAIIIFA+AXr2R4AE3R9XWkUAAQQQQAABBBBAAAEEEChOILFnkaAnduoJHAEEEEAAAQQQQAABBBBIokB4YyZBD+/cMDIEEEAAAQQQQAABBBBAAIGoCZQwXhL0EvA4FQEEEEAAAQQQQAABBBBAAAGvBPJJ0L3qi3YQQAABBBBAAAEEEEAAAQQQQKAJgRAk6E2MjN0IIIAAAggggAACCCCAAAIIJEgg/gl6giaTUBFAAAEEEEAAAQQQQAABBKIrQIJe4txxOgIIIIAAAggggAACCCCAAAJeCJCge6HoXxu0jAACCCCAAAIIIIAAAgggkBABEvSETHTuMNmLAAIIIIAAAggggAACCCAQFgES9LDMRBzHQUwIIIAAAggggAACCCCAAAJ5C5Cg501FxbAJMB4EEEAAAQQQQAABBBBAIE4CJOhxmk1i8VKAthBAAAEEEEAAAQQQQACBQAVI0APlpjMEXAGWCCCAAAIIIIAAAggggEBDARL0hh5sIRAPAaJAAAEEEEAAAQQQQACByAmQoEduyhgwAuUXYAQIIBC8wMraOpv+6Fx7au6r9s67i1ocgFtf5yzIo36LDVIBAQQQQAABBHwXIEH3nZgOEECgQAGqI4BADoGPlyyz4WPH27ARd9iQS24wbeeolt41aepsp77OUZKePsAKAggggAACCIRWgAQ9tFPDwBBAwB8BWkUgmgJ77NbHevfq7gy+ZtVq5266s9HEx6QHHksfObr/Ael1VhBAAAEEEEAgvAIk6OGdG0aGAAJRFGDMCPgocOHgQenWm7srPm/+AlMSr8r99utrKlqnIIAAAggggEC4BUjQwz0/jA4BBBBoIMBGsgUyE+3FS5Y5v0fPJXL3xOnp3ZlJfXonKwgggAACCCAQSgES9FBOC4NCAAEEyiJApyEX2L5Xdxt0XP/0KO+dOju97q7o7rmKtqs6deTuuSAoCCCAAAIIRESABD0iE8UwEUAAgegLEIEXAkMzHnNXIp79srgn576a7uac045Nr7OCAAIIIIAAAuEXIEEP/xwxQgQQQACBfAQSUkd30TMfdR+X8Ti786fVZs1xJHT3/JxTBzrrfCCAAAIIIIBANARI0KMxT4wSAQQQQKDMAmHqPvMx95fmL0gPTX9azX053NGHH2hdOlemj7GCAAIIIIAAAuEXIEEP/xwxQgQQQACB+AsUFKESdPdPrullce4b3TP/tJrqFNQolRFAAAEEEECg7AIk6GWfAgaAAAIIIIBA4QKZb2dXgq7fo7t3z/UIvMpXrbKGAAIIIIAAAlEQIEGPwiwxRgQQQAABBLIEMhNwJeeDLx2brhH43fN0z6wggAACCCCAQCkCJOil6HEuAggggAACZRLQy+JyJeJ6OdyA/geUaVT+dEurCCCAAAIIJEWABD0pM02cCCCAAAKxE/hhjre060+r8XK4gqaayggggAACCIRGgAQ9NFPBQBBAAAEEEChMYI/d+ljmo+46mz+tJoUwFcaCAAIIIIBA/gIk6PlbURMBBBBAAIHQCehRd3dQSta5e+5qJGRJmAgggAACsRIgQY/VdBIMAggggEDSBJ6c80o65Mw3u6d3soJACQKcigACCCAQrAAJerDe9IYAAggggIBnAk/NfdX402qecdJQ8AL0iAACCCCQJUCCngXCJgIIIIAAAlERuHfq7PRQj+bN7WkLVhCoF+ATAQQQiJ4ACXr05owRI4AAAgggYPPmL3CKKPSn1U4+rr9WKQggEJQA/SCAAAI+CJCg+4BKkwgggAACCPgtcPfE6eku+NNqaQpWEIiNAIEggEAyBUjQkznvRI0AAgggEHGBjz/5zHr37GZ9d+tj/Gm1iE8mw0cgeAF6RACBkAqQoId0YhgWAggggAACzQk8PuUWU5k2fpTxp9Wak+IYAggEL0CPCCBQrAAJerFynIcAAggggAACCCCAAALBC9AjAjEWIEGP8eQSGgIIIIAAAggggAACCBQmQG0EyilAgl5OffpGAAEEEEAAAQQQQACBJAkQKwLNCpCgN8vDQQQQQAABBBBAAAEEEEAgKgKMM+oCJOhRn0HGjwACCCCAAAIIIIAAAggEIUAfvguQoPtOTAcIIIAAAggggAACCCCAAAItCXDcjASdbwECCCCAAAIIIIAAAggggEDcBSIRHwl6JKaJQSKAAAIIIIAAAggggAACCIRXwJuRkaB740grCCCAAAIIIIAAAggggAACCJQk0GSCXlKrnIwAAggggAACCCCAAAIIIIAAAgUJlCtBL2iQVEYAAQQQQAABBBBAAAEEEEAg7gIxTdDjPm3EhwACCCCAAAIIIIAAAgggEDcBEvRiZpRzEEAAAQQQQAABBBBAAAEEEPBYgATdY1AvmqMNBBBAAAEEEEAAAQQQQACB5AmQoCdvzokYAQQQQAABBBBAAAEEEEAghAIk6CGclGgPidEjgAACCCCAAAIIIIAAAggUI0CCXowa55RPgJ4RQAABBBBAAAEEEEAAgZgKkKDHdGIJqzgBzkIAAQQQQAABBBBAAAEEyiVAgl4uefpNogAxI4AAAggggAACCCCAAAJNCpCgN0nDAQSiJsB4EUAAAQQQQAABBBBAIMoCJOhRnj3GjkCQAvSFAAIIIIAAAggggAACvgqQoPvKS+MIIJCvAPUQQAABBBBAAAEEEEi6AAl60r8BxI9AMgSIEgEEEEAAAQQQQACB0AuQoId+ihggAgiEX4ARIoAAAggggAACCCBQugAJeumGtIAAAgj4K0DrCCCAAAIIIIAAAokQIEFPxDQTJAIIINC0AEcQQAABBBBAAAEEwiFAgh6OeWAUCCCAQFwFiAsBBBBAAAEEEEAgTwES9DyhqIYAAgggEEYBxoQAAggggAACCMRHgAQ9PnNJJAgggAACXgvQHgIIIIAAAgggEKAACXqA2HSFAAIIIIBApgDrCCCAAAIIIIBApgAJeqYG6wgggAACCMRHgEgQQAABBBBAIGICJOgRmzCGiwACCCCAQDgEGAUCCCCAAAIIeC1Agu61KO0hgAACCCCAQOkCtIAAAggggEACBUjQEzjphIwAAggggEDSBYgfAQQQQACBMAqQoIdxVhgTAggggAACCERZgLEjgAACCCBQlAAJelFsnIQAAggggAACCJRLgH4RQAABBOIqQIIe15klLgQQQAABBBBAoBgBzkEAAQQQKJsACXrZ6OkYAQQQQAABBBBIngARI4AAAgg0LUCC3rQNRxBAAAEEEEAAAQSiJcBoEUAAgUgLkKBHevoYPAIIIIAAAggggEBwAvSEAAII+CtAgu6vL60jgAACCCCAAAIIIJCfALUQQCDxAiToif8KAIAAAggggAACCCCQBAFiRACB8AuQoId/jhghAggggAACCCCAAAJhF2B8CCDggQAJugeINIEAAggggAACCCCAAAJ+CtA2AskQIEFPxjwTJQIIIIAAAggggAACCDQlwH4EQiJAgh6SiWAYCCCAAAIIIIAAAgggEE8BokIgXwES9HylqIcAAggggAACCCCAAAIIhE+AEcVIgAQ9RpNJKAgggAACCCCAAAIIIICAtwK0FqQACXqQ2vSFAAIIIIAAAggggAACCCDwlQBrDQRI0BtwsIEAAggggAACCCCAAAIIIBAXgajFQYIetRljvAgggAACCCCAAAIIIIAAAmEQ8HwMJOiek9IgAggggAACCCCAAAIIIIAAAoULNEzQCz+fMxBAAAEEEEAAAQQQQAABBBBAwAOBQBN0D8ZLEwgggAACCCCAAAIIIIAAAgjEUiBOCXosJ4igEEAAAQQQQAABBBBAAAEEkiFAgp73PFMRAQQQQAABBBBAAAEEEEAAAf8ESND9sy2sZWojgAACCCCAAAIIIIAAAggkWoAEPSHTT5gIIIAAAggggAACCCCAAALhFiBBD/f8RGV0jBMBBBBAAAEEEEAAAQQQQKBEARL0EgE5PQgB+kAAAQQQQAABBBBAAAEE4i9Agh7/OSbClgQ4jgACCCCAAAIIIIAAAgiEQIAEPQSTwBDiLUB0CCCAAAIIIIAAAggggEA+AiTo+ShRB4HwCjAyBBBAAAEEEEAAAQQQiIkACXpMJpIwEPBHgFYRQAABBBBAAAEEEEAgKAES9KCk6QcBBBoLsAcBBBBAAAEEEEAAAQTSAiToaQpWEEAgbgLEgwACCCCAAAIIIIBAlARI0KM0W4wVAQTCJMBYEEAAAQQQQAABBBDwVIAE3VNOGkMAAQS8EqAdBBBAAAEEEEAAgaQJkKAnbcaJFwEEEJAABQEEEEAAAQQQQCB0AiTooZsSBoQAAghEX4AIEEAAAQQQQAABBAoXIEEv3IwzEEAAAQTKK0DvCCCAAAIIIIBALAVI0GM5rQSFAAIIIFC8AGcigAACCCCAAALlESBBL487vSKAAAIIJFWAuBFAAAEEEEAAgSYESNCbgGE3AggggAACURRgzAgggAACCCAQXQES9OjOHSNHAAEEEEAgaAH6QwABBBBAAAEfBUjQfcSlaQQQQAABBBAoRIC6CCCAAAIIJFuABD3Z80/0CCCAAAIIJEeASBFAAAEEEAi5AAl6yCeI4SGAAAIIIIBANAQYJQIIIIAAAqUKkKCXKsj5CCCAAAIIIICA/wL0gAACCCCQAAES9ARM7u3XFgAAB8NJREFUMiEigAACCCCAAALNC3AUAQQQQCAMAiToYZgFxoAAAggggAACCMRZgNgQQAABBPISIEHPi4lKCCCAAAIIIIAAAmEVYFwIIIBAXARI0OMyk8SBAAIIIIAAAggg4IcAbSKAAAKBCZCgB0ZNRwgggAACCCCAAAIIZAuwjQACCHwlQIL+lQVrCCCAAAIIIIAAAgjES4BoEEAgUgIk6JGaLgaLAAIIIIAAAggggEB4BBgJAgh4K0CC7q0nrSGAAAIIIIAAAggggIA3ArSCQOIESNATN+UEjAACCCCAAAIIIIAAAmYYIBA+ARL08M0JI0IAAQQQQAABBBBAAIGoCzB+BIoQIEEvAo1TEEAAAQQQQAABBBBAAIFyCtB3PAVI0OM5r/+f/TpJahiIoQDK/U/NikqFwqnG7kHDW4EntfSUzTcVAQIECBAgQIAAAQIECCQTENCTLSxGu7ogQIAAAQIECBAgQIAAgdkCAvpsUfWeC6hAgAABAgQIECBAgACBhgICesOldx/Z/AQIECBAgAABAgQIEIgoIKBH3IqeMgvonQABAgQIECBAgAABArcEBPRbbD4icErAuQQIECBAgAABAgQIVBUQ0Ktu1lwE7gj4hgABAgQIECBAgACBYwIC+jF6BxPoJ2BiAgQIECBAgAABAgSuBQT0axtPCBDIJaBbAgQIECBAgAABAqkFBPTU69M8AQL7BJxEgAABAgQIECBAYK2AgL7WV3UCBAiMCXiLAAECBAgQIECgvYCA3v4nAIAAgQ4CZiRAgAABAgQIEIgvIKDH35EOCRAgEF1AfwQIECBAgAABAhMEBPQJiEoQIECAwEoBtQkQIECAAAECPQQE9B57NiUBAgQIXAm4T4AAAQIECBAIIiCgB1mENggQIECgpoCpCBAgQIAAAQKjAgL6qJT3CBAgQIBAPAEdESBAgAABAoUEBPRCyzQKAQIECBCYK6AaAQIECBAgsFNAQN+p7SwCBAgQIEDgJeA/AgQIECBA4E1AQH/jcEGAAAECBAhUETAHAQIECBDIJiCgZ9uYfgkQIECAAIEIAnogQIAAAQLTBQT06aQKEiBAgAABAgSeCvieAAECBDoKCOgdt25mAgQIECBAoLeA6QkQIEAgpICAHnItmiJAgAABAgQI5BXQOQECBAjcExDQ77n5igABAgQIECBA4IyAUwkQIFBWQEAvu1qDESBAgAABAgQI/F/AFwQIEDgnIKCfs3cyAQIECBAgQIBANwHzEiBA4IOAgP4BxyMCBAgQIECAAAECmQT0SoBAbgEBPff+dE+AAAECBAgQIEBgl4BzCBBYLCCgLwZWngABAgQIECBAgACBEQHvECAgoPsNECBAgAABAgQIECBQX8CEBBIICOgJlqRFAgQIECBAgAABAgRiC+iOwAwBAX2GohoECBAgQIAAAQIECBBYJ6ByEwEBvcmijUmAAAECBAgQIECAAIG/BdyNIiCgR9mEPggQIECAAAECBAgQIFBRwEzDAgL6MJUXCRAgQIAAAQIECBAgQCCaQKV+BPRK2zQLAQIECBAgQIAAAQIECMwU2FpLQN/K7TACBAgQIECAAAECBAgQIPAj8P5XQH/3cEWAAAECBAgQIECAAAECBI4ITA/oR6ZwKAECBAgQIECAAAECBAgQSC6QLaAn59Y+AQIECBAgQIAAAQIECBD4W0BAf3NxQYAAAQIECBAgQIAAAQIEzggI6DvdnUWAAAECBAgQIECAAAECBC4EBPQLmIy39UyAAAECBAgQIECAAAECeQUE9Ly729258wgQIECAAAECBAgQIEBgoYCAvhBX6f8IeJcAAQIECBAgQIAAAQK9BQT03vvvM71JCRAgQIAAAQIECBAgEFxAQA++IO3lENAlAQIECBAgQIAAAQIEngoI6E8FfU9gvYATCBAgQIAAAQIECBBoICCgN1iyEQl8FvCUAAECBAgQIECAAIEIAgJ6hC3ogUBlAbMRIECAAAECBAgQIDAkIKAPMXmJAIGoAvoiQIAAAQIECBAgUEVAQK+ySXMQILBCQE0CBAgQIECAAAEC2wQE9G3UDiJAgMBvAdcECBAgQIAAAQIEXgIC+svCfwQIEKglYBoCBAgQIECAAIFUAgJ6qnVplgABAnEEdEKAAAECBAgQIDBXQECf66kaAQIECMwRUIUAAQIECBAg0E5AQG+3cgMTIECAwNcXAwIECBAgQIBAPAEBPd5OdESAAAEC2QX0T4AAAQIECBC4ISCg30DzCQECBAgQOCngbAIECBAgQKCmgIBec6+mIkCAAAECdwV8R4AAAQIECBwSENAPwTuWAAECBAj0FDA1AQIECBAgcCUgoF/JuE+AAAECBAjkE9AxAQIECBBILCCgJ16e1gkQIECAAIG9Ak4jQIAAAQIrBQT0lbpqEyBAgAABAgTGBbxJgAABAs0FBPTmPwDjEyBAgAABAl0EzEmAAAEC0QUE9Ogb0h8BAgQIECBAIIOAHgkQIEDgsYCA/phQAQIECBAgQIAAgdUC6hMgQKCDgIDeYctmJECAAAECBAgQ+CTgGQECBEIICOgh1qAJAgQIECBAgACBugImI0CAwJiAgD7m5C0CBAgQIECAAAECMQV0RYBAGQEBvcwqDUKAAAECBAgQIEBgvoCKBAjsE/gGAAD//+Oln3QAAAAGSURBVAMApOIVusIMXXQAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "structure = bulk(\"Al\", cubic=True).repeat(2)\n",
+    "fig = stk.visualize.plot3d(structure, mode=\"plotly\")\n",
+    "fig.show(renderer=\"png\", width=500, height=400, scale=2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "301955c3",
+   "metadata": {},
+   "source": [
+    "`plot3d()` accepts a `scalar_field` to color atoms by a per-atom property &ndash; this is a convenient way\n",
+    "to visualise the output of the analysis functions above. As an example, we color a small Al cell by the\n",
+    "centrosymmetry parameter after displacing one atom: the displaced atom (and, to a lesser extent, its\n",
+    "neighbors) lights up against the otherwise perfectly centrosymmetric lattice.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "097905b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T15:20:52.642989Z",
+     "iopub.status.busy": "2026-06-26T15:20:52.642533Z",
+     "iopub.status.idle": "2026-06-26T15:21:05.829754Z",
+     "shell.execute_reply": "2026-06-26T15:21:05.827505Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+gAAAMgCAYAAACwGEg9AAAQAElEQVR4AezdCYAcZZ338X/nIifKJRgQWEENoCzI4RVcxCUiuhIkCoLRgEHdkHArAcIVCAQFhQSCu0aJIAgaJLi6IqzIrsEDfIEVkSB4wEIACVfuc/p9fk93dXpqemb6qOqu4zs7Tz/11FP1HJ+arPz7qa4eUOQHAQQQQAABBBBAAAEEEEAAAQQ6LjDAYv2hcQQQQAABBBBAAAEEEEAAAQQQqEcg3QF6PTPkGAQQQAABBBBAAAEEEEAAAQRSIECA3sdFogoBBBBAAAEEEEAAAQQQQACBdgkQoLdLumc/7EEAAQQQQAABBBBAAAEEEECgIkCAXqHI2gbzQQABBBBAAAEEEEAAAQQQSJMAAXqarlaSxspYEEAAAQQQQAABBBBAAAEEIhUgQI+Uk8aiEqAdBBBAAAEEEEAAAQQQQCBvAgToebvizFcCJAQQQAABBBBAAAEEEEAgcQIE6Im7JAwo/QLMAAEEEEAAAQQQQAABBBBoXIAAvXEzzkCgswL0jgACCCCAAAIIIIAAApkUIEDP5GVlUgg0L8CZCCCAAAIIIIAAAggg0BkBAvTOuNMrAnkVYN4IIIAAAggggAACCCDQiwABei8w7EYAgTQKMGYEEEAAAQQQQAABBNIrQICe3mvHyBFAoN0C9IcAAggggAACCCCAQIwCBOgx4tI0Aggg0IgAxyKAAAIIIIAAAgjkW4AAPd/Xn9kjgEB+BJgpAggggAACCCCAQMIFCNATfoEYHgIIIJAOAUaJAAIIIIAAAggg0KoAAXqrgpyPAAIIIBC/AD0ggAACCCCAAAI5ECBAz8FFZooIIIAAAn0LUIsAAggggAACCCRBgAA9CVeBMSCAAAIIZFmAuSGAAAIIIIAAAnUJEKDXxcRBCCCAAAIIJFWAcSGAAAIIIIBAVgQI0LNyJZkHAggggAACcQjQJgIIIIAAAgi0TYAAvW3UdIQAAggggAACYQHKCCCAAAIIILBZgAB9swVbCCCAAAIIIJAtAWaDAAIIIIBAqgQI0FN1uRgsAggggAACCCRHgJEggAACCCAQrQABerSetIYAAggggAACCEQjQCsIIIAAArkTIEDP3SVnwggggAACCCCAgBkGCCCAAALJEyBAT941YUQIIIAAAggggEDaBRg/AggggEATAgToTaBxCgIIIIAAAggggEAnBegbAQQQyKYAAXo2ryuzQgABBBBAAAEEEGhWgPMQQACBDgkQoHcInm4RQAABBBBAAAEE8inArBFAAIHeBAjQe5NhPwIIIIAAAggggAAC6RNgxAggkGIBAvQUXzyGjgACCCCAAAIIIIBAewXoDQEE4hQgQI9Tl7YRQAABBBBAAAEEEECgfgGORCDnAgToOf8DYPoIIIAAAggggAACCORFgHkikHQBAvSkXyHGhwACCCCAAAIIIIAAAmkQYIwItCxAgN4yIQ0ggAACCCCAAAIIIIAAAnEL0H4eBAjQ83CVmSMCCCCAAAIIIIAAAggg0JcAdYkQIEBPxGVgEAgggAACCCCAAAIIIIBAdgWYWX0CBOj1OXEUAggggAACCCCAAAIIIIBAMgUyMyoC9MxcSiaCAAIIIIAAAggggAACCCAQvUD7WiRAb581PSGAAAIIIIAAAggggAACCCDQXaCqRIBehcEmAggggAACCCCAAAIIIIAAAp0SiCNA79Rc6BcBBBBAAAEEEEAAAQQQQACB1AqkMEBPrTUDRwABBBBAAAEEEEAAAQQQQKBXAQL0MA1lBBBAAAEEEEAAAQQQQAABBDogQIDeZnS6QwABBBBAAAEEEEAAAQQQQKCWAAF6LZX07mPkCCCAAAIIIIAAAggggAACKRUgQE/phevMsOkVAQQQQAABBBBAAAEEEEAgLgEC9LhkabdxAc5AAAEEEEAAAQQQQAABBHIsQICe44uft6kzXwQQQAABBBBAAAEEEEAgyQIE6Em+OowtTQKMFQEEEEAAAQQQQAABBBBoSYAAvSU+TkagXQL0gwACCCCAAAIIIIAAAlkXIEDP+hVmfgjUI8AxCCCAAAIIIIAAAggg0HEBAvSOXwIGgED2BZghAggggAACCCCAAAII9C9AgN6/EUcggECyBRgdAggggAACCCCAAAKZECBAz8RlZBIIIBCfAC0jgAACCCCAAAIIINAeAQL09jjTCwIIIFBbgL0IIIAAAggggAACCJQFCNDLEGQIIIBAFgWYEwIIIIAAAggggEB6BAjQ03OtGCkCCCCQNAHGgwACCCCAAAIIIBChAAF6hJg0hQACCCAQpQBtIYAAAggggAAC+RIgQM/X9Wa2CCCAAAKBADkCCCCAAAIIIJAwAQL0hF0QhoMAAgggkA0BZoEAAggggAACCDQqQIDeqBjHI4AAAggg0HkBRoAAAggggAACGRQgQM/gRWVKCCCAAAIItCbA2QgggAACCCDQCQEC9E6o0ycCCCCAAAJ5FmDuCCCAAAIIIFBTgAC9Jgs7EUAAAQQQQCCtAowbAQQQQACBtAoQoKf1yjFuBBBAAAEEEOiEAH0igAACCCAQmwABemy0NIwAAggggAACCDQqwPEIIIAAAnkWIEDP89Vn7ggggAACCCCQLwFmiwACCCCQaAEC9ERfHgaHAAIIIIAAAgikR4CRIoAAAgi0JkCA3pofZyOAAAIIIIAAAgi0R4BeEEAAgcwLEKBn/hIzQQQQQAABBBBAAIH+BTgCAQQQ6LwAAXrnrwEjQAABBBBAAAEEEMi6APNDAAEE6hAgQK8DiUMQQAABBBBAAAEEEEiyAGNDAIFsCBCgZ+M6MgsEEEAAAQQQQAABBOISoF0EEGiTAAF6m6DpBgEEEEAAAQQQQAABBGoJsA8BBAIBAvRAghwBBBBAAAEEEEAAAQSyJ8CMEEiRAAF6ii4WQ0UAAQQQQAABBBBAAIFkCTAaBKIUIECPUpO2EEAAAQQQQAABBBBAAIHoBGgpZwIE6Dm74EwXAQQQQAABBBBAAAEEECgJ8Jo0AQL0pF0RxoMAAggggAACCCCAAAIIZEGAOTQsQIDeMBknIIAAAggggAACCCCAAAIIdFogi/0ToGfxqjInBBBAAAEEEEAAAQQQQACBVgQ6ci4BekfY6RQBBBBAAAEEEEAAAQQQQCC/ArVnToBe24W9CCCAAAIIIIAAAggggAACCLRVILIAva2jpjMEEEAAAQQQQAABBBBAAAEEMiaQlgA9Y+xMBwEEEEAAAQQQQAABBBBAAIHuAgTo3oMXBBBAAAEEEEAAAQQQQAABBDorQIDeDn/6QAABBBBAAAEEEEAAAQQQQKAfAQL0foDSUM0YEUAAAQQQQAABBBBAAAEE0i9AgJ7+axj3DGgfAQQQQAABBBBAAAEEEECgDQIE6G1Apou+BKhDAAEEEEAAAQQQQAABBBCQAAG6FEjZFWBmCCCAAAIIIIAAAggggEBKBAjQU3KhGGYyBRgVAggggAACCCCAAAIIIBCVAAF6VJK0g0D0ArSIAAIIIIAAAggggAACORIgQM/RxWaqCHQXoIQAAggggAACCCCAAAJJEiBAT9LVYCwIZEmAuSCAAAIIIIAAAggggEBDAgToDXFxMAIIJEWAcSCAAAIIIIAAAgggkDUBAvSsXVHmgwACUQjQBgIIIIAAAggggAACbRcgQG87OR0igAACCCCAAAIIIIAAAggg0FOAAL2nCXsQQACBdAswegQQQAABBBBAAIFUChCgp/KyMWgEEECgcwL0jAACCCCAAAIIIBCPAAF6PK60igACCCDQnABnIYAAAggggAACuRUgQM/tpWfiCCCAQB4FmDMCCCCAAAIIIJBcAQL05F4bRoYAAgggkDYBxosAAggggAACCLQgQIDeAh6nIoAAAggg0E4B+kIAAQQQQACBbAsQoGf7+jI7BBBAAAEE6hXgOAQQQAABBBDosAABeocvAN0jgAACCCCQDwFmiQACCCCAAAL9CRCg9ydEPQIIIIAAAggkX4ARIoAAAgggkAEBAvQMXESmgAACCCCAAALxCtA6AggggAAC7RAgQG+HMn0ggAACCCCAAAK9C1CDAAIIIICAFyBA9wy8IIAAAggggAACWRVgXggggAACaREgQE/LlWKcCCCAAAIIIIBAEgUYEwIIIIBAZAIE6JFR0hACCCCAAAIIIIBA1AK0hwACCORJgAA9T1ebuSKAAAIIIIAAAghUC7CNAAIIJEqAAD1Rl4PBIIAAAggggAACCGRHgJkggAACjQkQoDfmxdEIIIAAAggggAACCCRDgFEggEDmBAjQM3dJmRACCCCAAAIIIIAAAq0L0AICCLRfgAC9/eb0iAACCCCAAAIIIIBA3gWYPwII1BAgQK+Bwi4EEEAAAQQQQAABBBBIswBjRyCdAgTo6bxujBoBBBBAAAEEEEAAAQQ6JUC/CMQkQIAeEyzNIoAAAggggAACCCCAAALNCHBOfgUI0PN77Zk5AggggAACCCCAAAII5E+AGSdYgAA9wReHoSGAAAIIIIAAAggggAAC6RJgtK0IEKC3ose5CCCAAAIIIIAAAggggAAC7RPIeE8E6Bm/wEwPAQQQQAABBBBAAAEEEECgPoFOH0WA3ukrQP8IIIAAAggggAACCCCAAAJ5EOh3jgTo/RJxAAIIIIAAAggggAACCCCAAALxC7QWoMc/PnpAAAEEEEAAAQQQQAABBBBAIBcCiQ7Qc3EFmCQCCCCAAAIIIIAAAggggAACTiDPAbqbPr8IIIAAAggggAACCCCAAAIIJEOAAD2260DDCCCAAAIIIIAAAggggAACCNQvQIBev1WyjmQ0CCCAAAIIIIAAAggggAACmRIgQM/U5YxuMrSEAAIIIIAAAggggAACCCDQXgEC9PZ601tJgFcEEEAAAQQQQAABBBBAAIGQAAF6CIRiFgSYAwIIIIAAAggggAACCCCQPgEC9PRdM0bcaQH6RwABBBBAAAEEEEAAAQRiECBAjwGVJhFoRYBzEUAAAQQQQAABBBBAIJ8CBOj5vO7MOr8CzBwBBBBAAAEEEEAAAQQSKkCAntALw7AQSKcAo0YAAQQQQAABBBBAAIFmBQjQm5XjPAQQaL8APSKAAAIIIIAAAgggkGEBAvQMX1ymhgACjQlwNAIIIIAAAggggAACnRQgQO+kPn0jgECeBJgrAggggAACCCCAAAJ9ChCg98lDJQIIIJAWAcaJAAIIIIAAAgggkHYBAvS0X0HGjwACCLRDgD4QQAABBBBAAAEEYhcgQI+dmA4QQAABBPoToB4BBBBAAAEEEEDAjACdvwIEEEAAgawLMD8EEEAAAQQQQCAVAgToqbhMDBIBBBBAILkCjAwBBBBAAAEEEIhGgAA9GkdaQQABBBBAIB4BWkUAAQQQQACB3AgQoOfmUjNRBBBAAAEEegqwBwEEEEAAAQSSI0CAnpxrwUgQQAABBBDImgDzQQABBBBAAIEGBAjQG8DiUAQQQAABBBBIkgBjQQABBBBAIFsCBOjZJPqoCwAAEABJREFUup7MBgEEEEAAAQSiEqAdBBBAAAEE2ixAgN5mcLpDAAEEEEAAAQQkQEIAAQQQQCAsQIAeFqGMAAIIIIAAAgikX4AZIIAAAgikUIAAPYUXjSEjgAACCCCAAAKdFaB3BBBAAIE4BAjQ41ClTQQQQAABBBBAAIHmBTgTAQQQyKkAAXpOLzzTRgABBBBAAAEE8irAvBFAAIGkChCgJ/XKMC4EEEAAAQQQQACBNAowZgQQQKBpAQL0puk4EQEEEEAAAQQQQACBdgvQHwIIZFmAAD3LV5e5IYAAAggggAACCCDQiADHIoBARwUI0DvKT+cIIIAAAggggAACCORHgJkigEDfAgTofftQiwACCCCAAAIIIIAAAukQYJQIpF6AAD31l5AJIIAAAggggAACCCCAQPwC9IBA/AIE6PEb0wMCCCCAAAIIIIAAAggg0LcAtQg4AQJ0h8AvAggggAACCCCAAAIIIJBlAeaWDgEC9HRcJ0aJAAIIIIAAAggggAACCCRVgHFFJECAHhEkzSCAAAIIIIAAAggggAACCMQhkJ82CdDzc62ZKQIIIIAAAggggAACCCCAQFggQWUC9ARdDIaCAAIIIIAAAggggAACCCCQLYFGZkOA3ogWxyKAAAIIIIAAAggggAACCCAQk0ATAXpMI6FZBBBAAAEEEEAAAQQQQAABBHIskLwAPccXg6kjgAACCCCAAAIIIIAAAgjkVyB3AXp+LzUzRwABBBBAAAEEEEAAAQQQSLIAAXq0V4fWEEAAAQQQQAABBBBAAAEEEGhKgAC9KbZOnUS/CCCAAAIIIIAAAggggAACWRUgQM/qlW1mXpyDAAIIIIAAAggggAACCCDQMQEC9I7R569jZowAAggggAACCCCAAAIIINC7AAF67zbUpEuA0SKAAAIIIIAAAggggAACqRYgQE/15WPw7ROgJwQQQAABBBBAAAEEEEAgXgEC9Hh9aR2B+gQ4CgEEEEAAAQQQQAABBHIvQICe+z8BAPIgwBwRQAABBBBAAAEEEEAg+QIE6Mm/RowQgaQLMD4EEEAAAQQQQAABBBCIQIAAPQJEmkAAgTgFaBsBBBBAAAEEEEAAgXwIEKDn4zozSwQQ6E2A/QgggAACCCCAAAIIJESAAD0hF4JhIIBANgWYFQIIIIAAAggggAAC9QoQoNcrxXEIIIBA8gQYEQIIIIAAAggggECGBAjQM3QxmQoCCCAQrQCtIYAAAggggAACCLRTgAC9ndr0hQACCCCwWYAtBBBAAAEEEEAAgW4CBOjdOCgggAACCGRFgHkggAACCCCAAAJpEyBAT9sVY7wIIIAAAkkQYAwIIIAAAggggEDkAgTokZPSIAIIIIAAAq0KcD4CCCCAAAII5FGAAD2PV505I4AAAgjkW4DZI4AAAggggEAiBQjQE3lZGBQCCCCAAALpFWDkCCCAAAIIINCcAAF6c26chQACCCCAAAKdEaBXBBBAAAEEMitAgJ7ZS8vEEEAAAQQQQKBxAc5AAAEEEECgcwIE6J2zp2cEEEAAAQQQyJsA80UAAQQQQKAPAQL0PnCoQgABBBBAAAEE0iTAWBFAAAEE0i1AgJ7u68foEUAAAQQQQACBdgnQDwIIIIBAzAIE6DED0zwCCCCAAAIIIIBAPQIcgwACCCBAgM7fAAIIIIAAAggggED2BZghAgggkAIBAvQUXCSGiAACCCCAAAIIIJBsAUaHAAIIRCFAgB6FIm0ggAACCCCAAAIIIBCfAC0jgEBOBAjQc3KhmSYCCCCAAAIIIIAAArUF2IsAAkkRIEBPypVgHAgggAACCCCAAAIIZFGAOSGAQN0CBOh1U3EgAggggAACCCCAAAIIJE2A8SCQJQEC9CxdTeaCAAIIIIAAAggggAACUQrQFgJtFSBAbys3nSGAAAIIIIAAAggggAACgQA5At0FCNC7e1BCAAEEEEAAAQQQQAABBLIhwCxSJ0CAnrpLxoARQAABBBBAAAEEEEAAgc4LMILoBQjQozelRQQQQAABBBBAAAEEEEAAgdYEcnk2AXouLzuTRgABBBBAAAEEEEAAAQTyLJDMuROgJ/O6MCoEEEAAAQQQQAABBBBAAIG0CjQ5bgL0JuE4DQEEEEAAAQQQQAABBBBAAIEoBeoN0KPsk7YQQAABBBBAAAEEEEAAAQQQQCAkkJAAPTQqiggggAACCCCAAAIIIIAAAgjkTCAfAXrOLirTRQABBBBAAAEEEEAAAQQQSJ8AAXoE14wmEEAAAQQQQAABBBBAAAEEEGhVgAC9VcH4z6cHBBBAAAEEEEAAAQQQSJnAa+vebMvX72bKX1v/Zp9nuZyyy5PY4RKgJ/bStGtg9IMAAggggAACCCCAAAJRCxRcg8Wuopn7tS6zrJeNn0gECNAjYaSRXgWoQAABBBBAAAEEEEAghwJFH5S7sNwF6AUXnme9nMNLHMuUCdBjYaXRdgnQDwIIIIAAAggggAACSRQouMDc3Ap6oViwUu5GmeGymx2/EQgQoEeASBOZFWBiCCCAAAIIIIAAAgg0J+AC9IJbObdi0b0WTLe6F9yWLytoL5orFdz+YjmvKqex3viJQoAAPQpF2kCgKQFOQgABBBBAAAEEEMiqQGnl3Ey5Pouu3H8W3QXfRQXtLq+UKyvr5eNTWG/8RCJAgB4JI40gkEABhoQAAggggAACCCDQMQEF4Vo19yvmbo1ceXU5c/Udk85WxwTo2bqezAaBtgnQEQIIIIAAAggggEDvAn7FvOjqyyvlpryqnLl6N1V+WxcgQG/dkBYQQCB6AVpEAAEEEEAAAQTSLeCC8YJLWjkv5WalvFjOM1Y2fqIQIECPQpE2EEAgZQIMFwEEEEAAAQQQiFegFIybC8b1IDjlZla0zJaNn0gECNAjYaQRBBBAoEqATQQQQAABBBBAoMsRhG5rtyyX3XT5bV2AAL11Q1pAAAEE2ipAZwgggAACCCCQEgH/NHY3Vpe7V7eCXnQr6G4rq2U3NX5bEyBAb82PsxFAAIGsCTAfBBBAAAEEEIhCwK2gF9yKebGcW9FccF6wSrm8v1JOe73xE4UAAXoUirSBAAIIIFCnAIchgAACCCCQD4FC+avVKrkL1n2Qrv1dRfdaKK2ouy1zK+oK5tNcn4+rGv8sCdDjN6YHBBBAAIF2CdAPAggggAACSRFQEK6gvFvuBqeygnLlWap3U+O3dQEC9NYNaQEBBBBAICcCTBMBBBBAAIF6BQouCPe3rysvmnst397utir7dZu7yhmoN34iESBAj4SRRhBAAAEEEGhZgAYQQAABBLIk4INvs6JfKXcTqy67olWXXYDerZzGeo2Z1LIAAXrLhDSAAAIIIIBAGgQYIwIIIIBA2wV8EF4wBd++76yX/SR5aUWAAL0VPc5FAAEEEEAAgZIArwgggAAC3QV8MO525SV3U+W3dQEC9NYNaQEBBBBAAAEEYhageQQQQCBtAoWq29a1gp71ctquT1LHS4Ce1CvDuBBAAAEEEECgXQL0gwACCEQvoADdgtvbXZ71cvSCuWyRAD2Xl51JI4AAAggggED7BOgJAQRyKVD+CjVTYK4Hxflg3RXcr7myZaw+l9c4hkkToMeASpMIIIAAAggggEDbBOgIAQSSKVAsupC8tHJecFv+ae4ut6K514JZxuqNn0gECNAjYaQRBBBAAAEEEEAgmwLMCgEEmhMolFfIS7lZ7bzYy/7g+PTUGz+RCBCgR8JIIwgggAACCCCAAAJNCHAKAtkVqKyQF91quZumL5dyraJvXkHPSL2bGr+tCxCgt25ICwgggAACCCCAAAKJFGBQCHROQCvmxS7Xv1bSXQye9bKbKb8RCBCgR4BIEwgggAACCCCAAAI5FGDKCPQh4BbMreACc62WK896uQ8KqhoQIEBvAItDEUAAAQQQQAABBBBolwD9pFtAQXkQnOchT/fVSs7oCdCTcy0YCQIIIIAAAggggAAC7RKgn7gF3Op5Qbe3d5lbSddT28u5L5v/XHqm6t2U+G1dgAC9dUNaQAABBBBAAAEEEEAAgW4CFHzwXSyaC82tqFzBunJH47Jy0J6dejctfiMQIECPAJEmEEAAAQQQQAABBBBAoI0CKeiq2FV0q+QuPPcr5sq7lzNXn4JrkoYhEqCn4SoxRgQQQAABBBBAAAEEEGibQBQdFbR2rqXyXvLs1UehRhsE6PwNIIAAAggggAACCCCAAAJRC7gVdH+be8+8dHt71vZH7ZfT9gjQc3rhmTYCCCCAAAIIIIAAAgjEJ1BaITe3fl4w023ubss/zV15rOXO9Gf8RCJAgB4JI40ggAACCCCAAAIIIIAAAlUCboVcAbmCc7+3quxCaBe06zPprsYF6+61WznR9W68NcfnJ8FLqwIE6K0Kcj4CCCCAAAIIIIAAAggg0EPAhbGVYFaVm8tFt98qK+nmgnOXqsrprNccWk95b4EAPe9/AcwfAQQQQAABBBBAAAEEohdwQXjBBd0KtgtqPetlzTH5KfEjJEBP/CVigAgggAACCCCAAAIIIJA2gVJQXrRC0Y3cB+fKi5ktu9nxa60TEKC3bkgLCCCAAAIIIIAAAggggEB3AR+UuzC9aG4d3eVZLxs/UQj0GaBH0QFtIIAAAggggAACCCCAAAJ5EygUC1bsKroV83zkebu+cc23kwF6XHOiXQQQQAABBBBAAAEEEECgswJFF5y7tfOichesm/IslzurnZneMxygZ+YaMREEEEAAAQQQQAABBBBIm4CCct3WrtwF56Y8y+W0XZ+EjpcAvdkLw3kIIIAAAggggAACCCCAQG8CLigvFF2lzwvmV9CzXHZT5bd1AQL01g1jaYFGEUAAAQQQQAABBBBAIL0CBa2Yu4A8L3mjV2r9+g22ctWaRk/L/PEE6Jm/xDUnyE4EEEAAAQQQQAABBBCIU8AF59YjuZX0Ltdpj/3BvhTXuyn09bv0+WV2ww9+ZiecdrkdNH6a7TvuRHvXR/7V9jp4kk048QL7/n/ca2vWru+riT7rfvnb39tJ51xVV3pkyV/7bKuTlQTondTPbN9MDAEEEEAAAQQQQACBnAuUV9CtW67I3Lko67Zf+1xwXlSFtpVUDucJrndD7ev3iONn2OXXfs9++9Bj9vKrK7od+tgTT9lFVy6wE8/8atNB+rPuDYB7f/Ww1ZNeevm1bv0nqUCAnqSrwVjqE+AoBBBAAAEEEEAAAQQSLqCnt3cPzt2AfVCuwLtgmat306vn94B9xthpn/+EXXPpKfadq8+28077jO30xu38qQ/94Qm7dsHtfruVl48f/n6bOGFcrynor5U+4jqXAD0uWdpNrQADRwABBBBAAAEEEECgVYHgs+ebg3TXohbAfZBulrl66/vnyA+PtZvnnWcLrppuk4/9iH3gvfva/v/4NjvmiEPsu9eca8OHDfUN3Hf/Iz5v5eX0L3zCpk89tte0+z/s2ErzsZ5LgB4rL40j0EOAHQgggAACCMDQr6IAABAASURBVCCAAAJ5EFAgboWqlXK3cp7lcj/X9JyTP23/uOduNY/abpvX215v29XXPfPcMp/n9YUAPa9XnnlnVIBpIYAAAggggAACCCRCQAF6l1WtlJtZt7IL2LuVU17vht/srx4O9+jjf/On/+NetYN4X5mDFwL0HFxkpohAZAI0hAACCCCAAAIIIFCXQPAZ89Jz37SS7k5zQfvmctF0+/vmcrrr3egb/tVXrT34yJ/szJnzbPWatf78aSd83OetvLz62kp74cVX7LXlq0p3MLTSWJvPJUBvMzjdIYBA7wLUIIAAAggggAACWREIPmPu86qV8qyWG7lu9z+0xH/dmr5qbeK0S/2T17d+/Sibf8WXer0NvpH2P/qZs+2QT5xm7/3YSfb2Dxxvh3/6LLvph3fbipWrG2mmI8cSoHeEnU4RQKADAnSJAAIIIIAAAgi0TaDbyrj/7Lm6rrWSXrU/OK7bSns66jXKetPzL77kv26t+ng9LG7Pt5Y+h169P4rtp555wS6dc5Md/cWL/Kp6FG3G1QYBelyytIsAAjkTYLoIIIAAAggggMBmgeqV8mKwgl7OFbxnrX7zzPvf2uMtu9ipJ06wE4453A561zv8CfO+c4f989Fn2ON//j9fbvRl7z3ebDO/dILdMOcc+9GCWfbTm75i35t3np17ysTK17gpUD/l/LmNNt3W4wnQ28pNZwgggECTApyGAAIIIIAAAqkSUBBu5RXxQjnPctka+HnLP+xkJx73UTvji5+0b1x+hv3wWxf7r1nT59BPu+Aa6+oqNtBa6VCtvh/1kffbfnu/1XbbdUfbecc32N577mbHHvlBu/3bF9tb37yTP/CBh5fYspdf89tJfCFAT+JVYUwIIIBAmwXoDgEEEEAAAQSiFdAKebBynoe8Fb237fYmmzjhUN+EVrmXvhDtV60NHzbUJh39Yd++Xh574mlliUwE6Im8LAwKAQQQyJQAk0EAAQQQQCB3AlpBL5RXzvOQt3qBd33TDpUm/vr085XtqDa2326rSlOvvraisp20DQL0pF0RxoMAAggg0KAAhyOAAAIIIJA8AR+Ud7lx6YFvLs962c20pd/nXni5cv5227yush3VxtPP/r3S1M47bV/ZTtoGAXrSrgjjQQABBBBIlgCjQQABBBBAoAkBf1u7W0G3ornXgmW9bH38PPHXZ+x///jnXo94bcUq++5td1Xqd9tldGVbGy+9stwu/voNPs399g+1q1tavnK1PfDwkm77qgtr1q63b938k8qu3XfdsbKdtA0C9KRdEcaDAAIIIJArASaLAAIIIJBVgVJQbi48V3Ce/dx6/Xn40Sft2CkX28Rpl9pP7/mt/flvz9r69RtshQus7/3VwzZx6ix7+dXSbeef+9ThNnjwoG5tLXcB/C133GNK3//RL7rVqfD831+2SafOtgknXmB3/Ow+/yT4tevW2+o16+w3D/7R9T3TnnnuRR1qUz57hI0YPtRvJ/GFAD2JV4UxIYAAAgggEI0ArSCAAAIIdEqgy1xoXjCrmVsv+4PjU1jvhtzf74OP/MnOnHmdfWzSubbvuBPt3R+dYiedc5X9+aml/tS3v+0fbOrxR/rtZl4ee+IpO+eyb9rHP3ee7fehz9sBH/6Cfe70r9if/vKMb05PdZ983Ef9dlJfCNCTemUYFwIIIIAAAokXYIAIIIAAAr0LVK+gF91h1WVXdOH75pX1LNRrTrXTe/d/u2llvPpBbdVH6inr554y0W6aN8OGDBlcXeW3BwzYHLaGV9d1gNrtr/3pU4+1G+eeY1vUaF9tJCVtnmlSRsQ4EEAAAQQQQAABCZAQQACBNAt0mQvBzUor6C7synrZTbW33x132NZO/8In7Z4ffN0W3zHXFn7zIrv20lPtW1d+2e6+5Qr7zY/n2bFHftAGDRxYs4lddtreHr13gU9qI3zQ60aN8O3//Ptfs18svMq+/28X+vbnX/El+y+37/7/vM4mThjXa/vh9jpZdn8pneyevhFAAAEEEEAAgc4I0CsCCCAQr0DWV8zD86tPc6vXjbI93rKLHfzefezd++1po13wPnBgNGFpoVCwN2z7etvrbbv69t+z/172xjdsbYVCwdLyE41EWmbLOBFAAAEEEEAAgfYI0AsCCORdwK+Yu3DL5Z7C5QUr+BV1K+cFy1C98ROFgPuLiKIZ2kAAAQQQQAABBBBonwA9IYBA8gXcCnNRny13I3XBubmgvFTcHKQXSzsqQXupmNZ64ycCAQL0CBBpAgEEEEAAAQQQyJQAk0EAgdYFFJQXFWy75IJzfRbdfFlNu31Zq9e0SC0LEKC3TEgDCCCAAAIIIIAAAo0IcCwCuRHwC+guGPe5m7XPM1x2U+S3NQEC9Nb8OBsBBBBAAAEEEEAgWQKMBoFkCHQpEC9YsctF5X7lPOPlZKinfhQE6Km/hEwAAQQQQAABBBBAoH0C9IRAAwIuNi/o9naXWznfXDYzt39zuRAqp63ejZfflgUI0FsmpAEEEEAAAQQQQAABBCISoJnMCBQrnzF3U3Ir6MFKerA/yIPPpqe93s2S3wgECNAjQKQJBBBAAAEEEEAAAQTSIMAY2ydQKK+YWzkPyuE8K/XGTyQCBOiRMNIIAggggAACCCCAAAK5FwCgSsB/ZZpfOXc7lRfLeXllPWv1bnb8RiBAgB4BIk0ggAACCCCAAAIIIIBA3ALpar/ggvLgM+YKxrNeTtfVSe5oCdCTe20YGQIIIIAAAggggAACCLRLIOJ+FJSbC9KVKzhXnuVyxHy5bY4APbeXnokjgAACCCCAAAIIIIBAXAJBUK7cimbKFaQrz2I5Lse8tUuAnrcrznwRQAABBBBAAAEEEEAgdoEgGFdu1SvpVZ9BV7AeUb2pHd9eh9qPHTQnHRCg5+RCM00EEEAAAQQQQAABBBBon4APlotm1bmpbIXNwbTKVcF7cutL8+hrfMZPJAIE6JEw0ggCCCCAAAIIIIAAAgggsFmgsqJdFYRbVTCetfrNM29ii1MqAgToFQo2EEAAAQQQQAABBBBAAIGIBDIcjOvNhfCbDRGpxdJMmholQE/T1WKsCCCAAAIIIIAAAgggkA4BrZxXbme30m3tlXLB7TBXCm53d8Vux6ev3vL7E+nMCdAj5aQxBBDIu8Czzy+zGxfeZZNOnW1HTT7fDj36jEqaNmOOnTt7vj325NN5Z2L+CCCAAAIIZF7Af/Y8/MC2SrlY+mx6pWyhcvrqjZ9IBHoG6JE0SyMIIJBngeUrV9u8BYsqSUFrXx73LH6wcqy2+zo2yXWL7lxs444502Zfc7M98PASW+IC8aUvvGRB0tx0zHMuiE/yPBgbAggggAACCLQuoNvA3Tq4Wxo3t1I+oLyCbpktu5nxG4FA2wP0CMZMEwggkHCBLUcOt9tdsHqtC9KVtJqsoL3WsBXEamVZxymNcufWOi4N+1a4Nyaqxzn+sLGmVL1P25e5AL6/Ny10HAkBBBBAAAEEUiygz6AHK+RdRReYF6yY5XKKL1WShp61AD1JtowFgVwLLLhquo0aMcwbLHUrxlpR94WqFwXtCs6DXSdNGm8H7DMmKKY61zzOmnqsX0UPT0QeWk0P76eMAAIIIIAAAhkScDF5wa2dW7fchV+ubD32F1wAr70prjd+ohBwfwFRNJOXNpgnAgjUK7DjDtva9GnHVQ7X57KVKjvcxskz5piCVbdp4z/0PpviAnRtpzVVr4rrzYbL597kA3S9URGe2w0L70rrNBk3AggggAACCNQj0G0FXScU3Aq6i87dr1VW0t3+4DgXtBf9Srvbl8p6N25+WxYgQG+ZMMIGaAqBjAno9m4FqsG09NnsIIhVsK7PaatutAvmz6oK5rUvjSmYjwJybS/62X1+GpeefWKPOwP0xoTuIPAH8IIAAggggAAC2RPQh9Bd0F1ZQVfQ7ctutdznitTdtssKKqe9PntXsCMzIkDvCHtnOqVXBDohoJXjMbvvXOl60qmzTQ9KU7CunQpmdTu8PreucprTs8+96Ie/YtUa0+fpVZg+9Vg7ZOw7tdkj6fP3PXayAwEEEEAAAQSyIeBWxv1KuQu+S589d9NSEB7sD/Ks1Lvp8du6AAF664a0UBLgFYFeBeZccrJplVwHaOVYXzWmbaW5s04x3Q6v7bQnBebVc5g4YZwpVe9jGwEEEEAAAQRyIqAA3AXfptvWlQflysp6wUG4lJV6Nxt+WxcgQG/dkBbaIkAnaRZQAF59q3swF+3Tw9SCcpZyzUur58GceChcIEGOAAIIIIBAXgQUfGuueck1V1KrAgTorQpyfjYEmEXsAvo8evWt7urwA73c+q26tKXgs/Uat+4W0F0D2lbSE+z1mXttJyEtfWmNhdOK1Rv80JSH66Is+07cS5Rthtt6deV614PZ6nUbe8wzfGwr5U2bir6fF15ZG1s/y5av832s29AVWx8yUPvqSP2pHEeSk/qQWxztB23quqsf/R0E++LI1YdSf23rGBICCORTwN/W7lbOi10uQPe5/ndDD4oLynKpLqe7XrMhtS5AgN66IS0g0K8AB5gpSA1/5lpPca8ObNPsdMediyvD1xsRK1auNs1N8w4+j145gA0EEEAAAQQQyIGAC74Vcys49/kA83e3V8pZq8/BJW3DFAnQ24BMFwjELJD45vVE8+ogVQ+G06D1efTgYXEqZyXpdvZxx5xpStXzDs/v3Mu+Gd5FGQEEEEAAAQSyIqCgvOiC8ODBcL7sgvRu5QzVZ+W6dXgeBOgdvgB0j0DyBVoboVaRp517daURfS5bD4YLdiiY1SpzUCZHAAEEEEAAAQQyIaDg3KVCsGLutoOvXPMr6a5cdCkz9Zm4aJ2fBAF6568BI0AgswL6nm/dxh483Xz8h97nn2quB6jpAXF+4u5Fq8xaZXebqf3V18n19nVqumNA9dWT077bvnVx9S62EUAAAQQQQCBDAkW3Yl5w8ynlbuXcla0crBesVM5SvfETiQABeiSMNIIAArUEtDIefO5cD047a9pxlcMUsOrBccGOc2bP95/ZDspR5e1s58B9xtTsbrqbt96UqK784EH72ZYjh1fv6vj2vffea5fNutiu/Mqs2NKFF15oF7oUZx+zL73Y9zHrkpmxzUPjnznzIt/PFZdfEls/X7nsEt/HJRdfFFsfmova13VRfyrHkeSkPuQWR/tBm7ru6kd/B8G+OHL1oaS2f3Xf/3T83y8DQACBBAq41fHND4hz4/PlcK4QffNt7sXy7e+b8xTVu6nx27oAAXrrhrSAAAI1BPTUciVVabV47iUn9whIz5p6rClw1zH6PLpW27WdotRtqD9f/GC3sgp6E0JJ81M5SNoXbCchV3CuYOMyF9x+zQXocaWLLrrIlOJqX+1e7oJa9XHpJRebynElBZrq54rLZ8XWz1dnX+K9Lrl4Zmx9yEftay7qT+U4kpzUh9ziaD9oU9dd/ejvINgXR64+lIK2CdKT8P/JGANMRClvAAAQAElEQVQCyRLQyrlpxVxBt/KqFXS/PyhnpN74iUSAAD0SRhpBAIFqAX3u/Nrrb6/sOun4I01PNq/sKG9oBXnBVdNNAbx2abU9COpVTluqdZv+ojsX214HT7JzZ8/vNp1Jp86u446BbqfEWrj3v//b/tul97zvIDv9y+fGli644AJTirOPs86e4fs4Z8Z5sc1D4z///NJczjwrPq8vTS/NZcZ558c6F7Wv66L+NLc4kpzUh9ziaD9oU9dd/ejvINgXR64+lPRv5tf3/dKUYv1HSuMIIJA6gUJ1UB4Owl05e/Wpu0SJHDABeiIvC4NCIN0CO+6wrf3mJ9fZo/cu8GnihHG9TqiRY3tthIqGBEZvM8x8qspHDRvk2xj3z4fYlbplO6Z04YUX2oUuxdmHbm1WH7PcqnOc/Vx00YV+Llp1jqufr1xWul3/4pkXxXpd1P6F7rqov7jmIif1Ibe4+lC7uu7qR38HKseV1IeS/s3oH4/+DYX/XamsOhICCORTILhN3Vwwbi5Y93mxYD535czVGz9RCBCgR6FIGwggkHuB5StXV+4E0G37C+fPNKXrr5pus6ZPtimTxleM9CT7u265wvTmRGVnBjeYEgIIIIAAAvkWcMF4+TZ2Pb3dFJSHysH+IA9uiw/K4TzZ9cZPBAIE6BEg0gQCCCDw3YV3mZ5Wr9v1FZDr9n0lBeF6QJzypCgtfWmNhdOKNRv98JSH66Is+07cSwRt9phD0OarK9e7HsxWr9vY6zHBsa3kmzb5/8qyF15ZG1s/y5av83NZt6Ertj5koPbVkfpTOY4kJ/UhtzjaD9rUdVc/+jsI9sWRqw8l/ZsJ8lr9qI6EAAL5FAiCaZ+7lXPlhSBIL5ctVE5zvfETiQABeiSMNIIAAgiUBBSkH3/qbBt3zJndUvVn0Gdfc7OvO/ToM0on8ZpAAYaEAAIIIIBAiwIKwnV7u3K9p6s8y+UWuTi9JECAXnLgFQEEEEAAgfYJ0BMCCCCAQOYFtGJuwQp5DnLjJxIBAvRIGGkEAQTyLvDpCeNMnysPJ30GXemkqs+g6/Po+nz6gqvPzjsb849JgGYRQAABBJIgUDA9CM7ftu5WzsO5KWivsT84Lm31xk8kAgTokTDSCAII5F0g+Ly5PmtenQ7cZ4wp7e/ywEj1e+y+Mw+JC0DI0ybAeBFAAAEE6hHoUqhdCtItFIyrbBmrN34iESBAj4SRRhBAAAEEEEAgGgFaQQABBLIi4IJzffbcBeelp7EPsOC291I5a/VZuW6dnQcBemf96R0BBHIooK9hy+G0mTICyRBgFAgggECbBHwwrgfDuWQuFbXD5wUrld1AupVdNN+tnK56N1p+IxAgQI8AkSYQQACBegT0FWz1HMcxCCCQXgFGjgACCFQEfLDtSpW8vIJeKZdX0CvllNe7qfLbugABeuuGtIAAAgj0K6DPof/mJ9fZo/cu8J9J7/cEDkAAAQR6CrAHAQTSJOAWxM3KQbjLzZc3B+GlcobqjZ8oBAjQo1CkDQQQQAABBBBAIPUCTAABBKIVcMG3HgSnFfIutayyWUFlH6yrXCiVM1Fv/EQgQIAeASJNIIAAAggggAACCPQjQDUCORMofcWa+QfDFcytnLsg3IXjoXJ26o2fSAQI0CNhpBEEEEAAAQQQQACBTgrQNwLJEyitkJu5PFgxD+duhT079cZPBAIE6BEg0gQCCCCAAAIIIIBApgWYHAINC+ih7abg3K2cW3Bbu/LqcobqjZ9IBAjQI2GkEQQQQAABBBBAAAEEmhXgvEwKKBivXjHPejmTF7H9kyJAb785PSKAAAIIIIAAAggg0D4BeuqMgIJzF5SbcrdS7vMslzujnLleCdAzd0mZEAIIRC2wfOVqu2fxg7bozsXdkva32pfaePb5ZdZf0nGt9sX5CCCAAAIIxCFAm70IuGDc3+bucqu+rT2r5V4Y2N2YAAF6Y14cjQACORJQ0Dzp1Nn2no9OsWkz5ti5s+d3S+OOPsPvbyV4Pupz59m4Y87sNx3vxpEjeqaKAAIIIIBAIJDaXMF58NR2cyvoWS8bP5EIEKBHwkgjCCCQRYEHHl5iSsHcRo0YZqO338aUa9+KVWv8yno7guflK1apSxICCCCAAAIIRCoQZ2MF01etmYJzraArL9/u3mN/JuqNnwgECNAjQKQJBBDItsD4w8ba9VdNt9/85Dq7+9Yrfb7AlUfvsK2f+JInn/aBui80+XLAPmNs7iUn+37UV5AWzp9pd91yhd32rYubbJnTEEAAAQQQQKATAj4IV1AeBN/KizWCdu0PjktxfSeMs9gnAXoWrypzQgCBSAQOGftOHxzPmj7ZDnQBdHWjB7jySZPGV3YpSK8UmtjY0QX76k/9VKc9dt/ZVLflyOFNtMopCCCAAAIIINA5AReMuxXz8G3upmDc7Q/yVupr3TYftBvk7Wvf+IlAgAA9AkSaQACBbAooKFZw3NvsVB/UjSKADijIEUAAAQQQQEACbjW84JJfSXe5nuKusnLzZRc6uzzB9abx1j0+zZnUsgABesuENIAAAnkVuP3OxZWpj3Er3ZUCGwgggAACCCCAgILv8kq5KS8OMK14m9tvvlxaYTe3ol4qp7zeGvtZv36DrVy1prGTcnA0AXoOLjJTRACBaAT0tPb7H17iP2+up7vrq9fUsm511y3v2m42qV09JX72NTfbvAWLTF/p9tiTTzfbHOchgAACCCCAQIcFfDDugu+iAnKfKypXUF5wI1PuMr8/KKe7XrPpKy19fpnd8IOf2QmnXW4HjZ9m+4470d71kX+1vQ6eZBNOvMC+/x/32pq16/tqorG6lB5NgJ7SC8ewEUCg/QJ6WruSvnIteLq7HhY3peqz6M2OSv+jpaD8xoV32bUuQFewPmHy+aY3AvR1b822W+u84VsMtHAaPFD/cWCmPFwXZTkYT5RthtsaMmiA72bggEKPeYaPbaVcKJHZ0CE9PVtpt/rcoYMH+rm4qcQ6F1mpoy2cXXX/UW7LSX3ILcp2w20Fc9HfQbguyrLmojS4n387OoaEAAJ5FSiYvz1cQbgeBKcVdOVBOZynvb6fy3zE8TPs8mu/Z7996DF7+dUV3Y5+7Imn7KIrF9iJZ341NUF6twlEWCj9V0yEDdIUAgggkCeBG1xA3UoAveWoEZ5LX98WJL+j/KI3AqIO0l8/coiFUxA8KQ/XRVkuT6tH/1H2MXzoIN/NFoMHxtrPAEXNrqfXjRgcWz8jh5XmMtgFzlEahdsaVA4yRw2Pby5yclwmt3D/UZZ13dWP/g6ibDfclvpQ0r+ZIA8fo7LqSAggkE+BbsG5C8b9bew2oHvQ7vYHx6W+vs7LrLsOT/v8J+yaS0+x71x9tp132mdspzdu589+6A9PuIWK2/12Xl/KAXpep8+8EUAAgfoFgq8+09ehTZwwzkaNGFa53b3ZIF1tPnrvAv/1bfoKNyWVtTIffI2bVtd123v9I+37yNXrNlo4bdjk39I35eG6KMvByKJsM9zWug2bfDcbNxV7zDN8bCvlri7dimi2dv2m2PpR25qM+mplrP2dKyv1I7v+jm22PktzkYG8lPRvJsi1P5xUR0IAgXwKFBR8F/XqVtL9/2RU5e5/dlWj299LuYzSXq859J6O/PBYu3neeab/xpl87EfsA+/d1/b/x7fZMUccYt+95lwbPmyoP/m++x/xeV5f2hOg51WXeSOAQKYE9NR2fQWavg5t+tRj7aTjj/TzayWAVpu+kdCL3l3W/4AFu1v9GregHeWvrtxg4bR2vfsvBVepPFwXZdl14X+jbDPc1pp1pQB9/cZNPeYZPraVctH/x5bZa6t6erbSbvW5K9du9F4b3JsN1fuj3t5UfrNhxZqNsZnJSZORW9Tjr25P11396O+gen/U2+pDSf9mgrxWH6ojIYBAPgX8yrj73wr9/71C+fZ1PRXd3P/kFoKV9AzVWz8/55z8afvHPXeredR227ze9nrbrr7umeeW+TyvL5kI0PN68Zg3Agh0VkCr6LotXaNodgVd5/aW9BVvQftRBui99cd+BBBAAAEEEIhSoGDmVtCVFKSbX1E391OwoKw6paAczlWnFN4flFWnFJTDueqUwvuDsuqUgnI4V51SeH9QVp1Sqeym1uTvmrXr7dHH/+bP/se9agfxvjIHLwTo/V9kjkAAAQQQQAABBBBAAAEEGhIoBa3lYNwF6lkvN4RTPnj9+g324CN/sjNnzrPVa9b6vdNO+LjP8/pCgN7xK88AEEAgrQJaNV+xcnWfw9cxfR7QR6W+1i1oP1hJ7+NwqhBAAAEEEEAgUQIuOO9yAwqCc+XVZa2oV5fTXu+mWu/v/Q8t8V+3pq9amzjtUrv3Vw/b1q8fZfOv+FKvt8HX23bajyNAT/sV7G/81COAQNMCs6+52fS1ZwqUw41o38kz5tiKVWt8lT4z7jeqXnT+uGPOtL0OnuTbqarym2pbX6mmtvyO0Iu+ai1of/yHDwrVUkQAAQQQQACBJAv4z6C7INyKGqUL1st5pazgPEP1mmW96fkXX/Jft1Z9vB4Wt+dbS59Dr96ft20C9Lxd8YjnS3MIZFlAn/v2QfbRZ5iCZT1JfdGdi037jpp8vqle89fT1vV5dG1Xp2D1W/uqt1VW0vlqc1yN9g91gf09ix/UYdZb+76SFwQQQAABBBBIpEDBBd9BkK486+VGLsIeb9nFTj1xgp1wzOF20Lve4U+d95077J/dfxM9/uf/8+W8vhCg5/XKp2PejBKBRAhoFVuBuVa7Fahr5VtPbtfgFDwvuGq69fY0dh3TX4q7/f76px4BBBBAAAEEoheoDsqD4DzLeSOCb/mHnezE4z5qZ3zxk/aNy8+wH37rYv81a/oc+mkXXGP6etFG2svSsQToWbqazKVBAQ5HoG+BOZecbLOmT7bxh401fQa8OumWdn3V2t23XGF62nqtlj449p120qTxPun48DFnTT3W1IbaH7P7zt36UFl1Cv57az/cHmUEEEAAAQQQSJLA5tvauz0gTivr5dvds7W/efu37fYmmzjhUN/AU8+8YEtfyO9XrRGg+z8DXhCIQYAmUy+gVXEFzwrS7771SqtOCpxr3dZePelDXIA+xQXoSrUCdLWvNtT+bfNndmtfZdURnFeLso0AAggggEB6BHzwrQe/VQfjQTmcB0F7eH9QTkF9q1dm1zftUGnir08/X9nO2wYBet6uOPPNjAATQQABBBBAAAEEEEiwQHVwrQfCBeVwruA7C/UtXornXni50sJ227yusp23DQL0vF1x5otAfQIchQACCCCAAAIIINCCgF9BD4Jv5dUr6dVlBefV5fBxKanvi+qJvz5j//vHP/d6yGsrVtl3b7urUr/bLqMr23nbIEDP2xVnvggkQoBBIIAAAggggAACWRfgM+jBFX740Sft2CkX28Rpl9pP7/mt/flvz9r69RtM33Jz768etolTZ9nLr67wh3/uU4fb4MGD/HYeEXuHxwAAEABJREFUXwjQ83jVmTMCWRdgfggggAACCCCAQIcF/Ap6+Hb2DJfr4X7wkT/ZmTOvs49NOtf2HXeivfujU+ykc66yPz+11J/+9rf9g009/ki/ndcXAvS8XnnmjQACTQtwIgIIIIAAAggg0K9AhoPxmm8+9AHy3v3fbloZ3367rWoeNXzYUDv3lIl207wZNmTI4JrH5GUnAXperjTzRACBtAgwTgQQQAABBBDIgEDRBejW7bPlBbMMl62PH30rzelf+KTd84Ov2+I75trCb15k1156qn3ryi+bvrL2Nz+eZ8ce+UEbNHBgH63ko4oAPR/XmVkigECbBJ59fpktunOxTZsxxyadOrtbmn3NzfbAw0vaNJLeumE/AggggAACCLRHgM+g13Le6nWjbI+37GIHv3cfe/d+e9roHba1gQMJSwMrJAIJcgQQQKBFAQXn4445086dPd/uWfygD8YVkAfpxoV3+YB93oJFLfaU4NMZGgIIIIAAAgh4gaKexu5W0YsumUvFjJf9pHlpWYAAvWVCGkAAAQR6Cujd4PGHjbWTJo336YB9xlQOutYF6ArgKzvYqFuAAxFAAAEEEEiNQLeg3I0662U3RX5bFyBAb92QFhBAAIGKgILy66+a7j9PNWv6ZJviAnSlBW6fgvXgwJ+7FfZgmzwxAgwEAQQQQACByAT8irkNsFLe2+3u2amPDC7nDRGg5/wPgOkjgEB0AnoAioLyA6tWy6tbV6BeXWY7bwLMFwEEEEAgXwJVQXmXZq5y+UFxlXJ5f6Wc5nrNhdSqAAF6q4KcjwACCNQp8NiTT9d5JIch0IQApyCAAAIIJErAr5wXrbyCXl4pz3A5UfgpHgwBeoovHkNHAIH0COgBcifPmOMHPGrEMH/ruy/wgkBKBBgmAggggECDAv4z525F3Ofu3Jp5hurdFPltXYAAvXVDWkAAAQRqCujr1vREd33dmp7uvvT5Zf6rRC49+0TT7fA1T2InAvkUYNYIIIBA9gTcarmZbmu30o8vl1fStceXM1SvOZFaFiBAb5mQBhBAAIHaAgrQlfQ1a8ERelDcIWPfGRQ7km//+qEWTiOHDvJjUR6ui7LsO3EvUbYZbmvL4YNdD2ZDBw/sMc/wsa2UBw50qx6up2233CK2frYeOcT1YDbY9dXKWPs7d4vBA3w/W40YEttc5KRO5NbfeFqp13VXP/o72NxOz7/5VuvUh5L+zQR5rTZVR0IAgbwKBMG3y7v0vxkuD4LyymfOZeP2Z6JecyG1KlD6X+RWW+F8BBBAAIEeAh90gfiY3Xe20dtvY7qtXQdoRf3cy76pzY4lBUjhVNB/N7gRKQ/XRVl2XfjfKNsMtzVgQGkyysN1UZb9RNxLlG2G29IcXBemPFwXZVl9KEXZZq221IdSrbqo9slKfSiPqs1a7agPJf2bMbehvK/j3CH8IoBAzgS6FIQX3f8mVQfllfIAy1p9zi5vbNMlQI+NloYRQCDvAhMnjLPb5s+0u2+90u5yafyH3udJFv3sPpu3YJHf7sTLC6+stXBatXajH4rycF2UZd+Je4myzXBbr63a4HowW7t+U495ho9tpbxpk/8vLlu2fF1s/by8Yr2fy4aNXbH1IYN1G/RfkWavrlwfWz9y0mTkpj7jSrru6kd/B3H1oXbVh5L+zQS59oeT6lpNnI8AAmkVcCvj+p8KF5T7B8YFt7tntpzW65SscROgJ+t6MBoEEMiowJYjh9tZ046z0Tts62d4+52Lfd6Jl01dRQsnt8sPRXm4Lsqy78S9RNlmuK1i6b+CrMvl4booy24a/lcBZ5TtVrelOaiTdl2Xja6j6v4j3S6/oaH5RNpuaMyBmf4O4uxH81By3Stzf2/W49+V+veVyX5hdAggEJeAgnMXlJf+/0Sh/DT3gv//F+b2W8bqjZ9IBAjQI2GkEQQQQKB/AQXpwcPh9MC4/s/gCAQQQCDtAowfgTwLFCpBedHfqFQqF1xwXl22UDm99cZPBAIE6BEg0gQCCCBQr8CKlavrPZTjEEAAAQT6E6AegQQL+CC8WDALgnPlruz3B0G5K2elPsGXIlVDI0BP1eVisAggkGSB5f0E33qa+5Inn/ZTCB4a5wu8IIAAAggkUoBBIdCaQGnF3BSMl29nL2Y6N34iECBAjwCRJhBAAAEJXH7Nzfbuj/yrXbtgkT37/DLtqiQF5+fMnl8pT/zEhyrbbCCAAAII5FKASWdcoFYwXugnWE9zfcYvZ9umR4DeNmo6QgCBPAisWLXGP6F93DFn+mD9qMnn+3zSqbMt+Ny5vnpNT3jPgwdzRAABBBDolAD9dl6g0P329urgXLe7u3K329tduRLUp7K+8+JZGAEBehauInNAAIFECHxw7Dtt9PbbVMaiYF23tCsPdo4/bKxdf9V00wPjgn3kCCCAAAIIpE6AAfcroM+aFxV0u2C7UM6LxYJpvwXlcp6FeuMnEgEC9EgYaQQBBBAwO8QF6HffeqXddcsVNn3qsXbSpPGVNGv6ZL9fOcE5fy0IIIAAAgj0LZCNWheMFzWTzXnw1WpBXsxUveZKalWAAL1VQc5HAAEEQgL6KjXdwj7FBehB0sq59ocOpYgAAggggAAC7RdoS48Kvv3KuAvCi1o5d7lpxdzlxXKepXrjJxIBAvRIGGkEAQQQQAABBBBAAAEEEJBAkNzKeZfbrg7Og7JyBenKM1Pv5spvywIE6C0T0gACCCCAAAIIIIAAAggg0F2g8lnzorlQvBysu61iq+WEnm/8RCJAgB4JI40ggAACCCCAAAIIIIAAAtUCLih3wbSVg/K05M2P0/iJQIAAPQJEmkAAAQQQQAABBBBAAAEEqgWKxYIrloN0t531sptsPb8c048AAXo/QFQjgAACCCCAAAIIIIAAAo0LuOC8t8+YByvrmapvXCj6M9LfIgF6+q8hM0AAgTYI3P/wEqtOjz35dBt6pQsEEEAAAQQQSKtAsUtRuAvS3eq56TZ3BePKK+Vs1VseftowRwL0NiDTBQIIpFNgiQvCz5093w495kw7/tTZ3dKEyefbUS7ds/jBlianNvY6eJL1l3RcSx1xMgIIIIAAAgi0WWCAFRWD+6BcXStYr86zVq+5kVoR0LkE6FIgIYAAAjUEFKAvunOxLX1+WY1aM9VPmzHH5i1YVLO+np3LV6yq5zCr97i6GuMgBBBAAAEEEIhdoFtw7lbNs16OHTQnHcQYoOdEkGkigEBmBYLAfPxhY+36q6bbr388zx69d4EtcNsTJ4yrzPt2F8RXCk1ujNl9Zztp0nibNX1ytzT3kpN933NmndJky5yGAAIIIIAAAp0RcCvmXQWz6uBct7l3K2epvjPKWes1vQF61q4E80EAgcQJHOEC87tuucIHzAfuM8a2HDncj/EAtz196rGmwF07lroV9lZvdVeAPsUF6GqzOh0y9p2mvvdwAbz6IiGAAAIIIIBAOgSKCsbdUCsr577sgvbgtndfdvF7t3J6691U+Y1AgAC9F0R2I4AAAjvusK0p9SahQD2oW75ydbBJjgACCCCAAAIIOIGqYNutmlu3z6K7lfPMlY2fCAQI0CNAbKIJTkEAgQwIrCAoz8BVZAoIIIAAAgjEI+BXzovlB8G5VXJftlA5Q/XxKOavVQL0TF5zJoUAAu0Q+HnVE9yrV9Ob6Vtf4TZvwSLTQ+mUHnh4ibEq34wk5yCAAAIIIJAQAbdq7oPyINeKuW5rD8rhPPX1CXFP+TAI0FN+ATsyfDpFAAFTAK0kCgXnfd0Kr2P6S/oc+7UuQNfXuilNOnW2jTv6DNO+qAP1IYMHWDgNHFDwQ1Qerouy7DtxL1G2GW5Lc3BdmPJwXZRl9aG0RQ3PqPoZPLD0P9O6PFG1Wasdta+5qL9a9VHsGzyoNJeC+1OLor3e2higDtxkBjm73o6JYr/rwv8OHOAm5LaU12rXVfGLAAI5FfDBuYJut3puWjlXcF5d9vuD2+DdynrK63N6mSOfdul/LSNvlgYRaF6AMxFIusCzzy+zc2bPrwxTT1+vFCLcWLFqjf8Kt6Mmnx/pavq2W25h4TR8i4F+5MrDdVGWfSfuJco2w22NGj7Y9WC2xeCBPeYZPraV8sCBBd/P60cOia2f140ozUXBbStj7e9cta/JqL/+jm22futRQ9SFDXABbbNt1HPe0CEDfT8jhw2K7bpoHL4T96J/My4z5dofTqojIYBAXgWC4DsveV6vc7TzJkCP1pPWki/ACBFoSUDBuVa3teKthvQ0d62ga7uZpK9P05Pi9fVtQVJZX7c2asQw36T6+u7Cu/x2FC/rNnRZOG3q8m/jm/JwXZTlYPxRthlua+Om0lyUh+uiLLdjLhs2+uUU63LXJ8qxh9tS+5qP+gvXRVVW2+pDfUXVZq121L76UX+16qPapz6U9G8myGu1rToSAgjkU8CvoIdvY89wOZ9XOfpZE6BHb0qLuRZg8lkWCAfnWjmfOGFcS1PW16eFb49XWV+1NnfWKZW2qz/vXtnZ5MZLy9dZOK1et8m3pjxcF2XZd+Jeomwz3NbKNRtcD2brN27qMc/wsa2UN5XfCHh15frY+nltdWkuG1xfrYy1v3PVvtDUX3/HNlv/8or16sL0H6zNtlHPeWs3lP6WV63dGNt10Tj8ZNyL/s24zJRrfzipjoQAAjkVyHAwrv9fbuH55fQyRz1tAvSoRWkPgTgFaLtjArWC8ymTxsc6Hq3Mj95+G9/Hkief9jkvCCCAAAIIIJAOAR/EVj5znv3b3NNxVZI/SgL05F8jRohA2wToqLZAJ4Lz2iNhLwIIIIAAAgikRyD7QXn3NyHSc2WSPFIC9CRfHcaGQLYEUjkbrVyHP3Me98p5AKWnt69YudoXg5V0X+AFAQQQQAABBBIv4IPXHreBl4P28P6gHKy4B+VwnuD6xF+QlAyQAD0lF4phIoBAfwLR1y+6c7HpCep6SJse2Db3kpOtkc+c6yvS9jp4kh169BmmtsIj1D6l8P6gPG/BItOT3FUe/+GDlJEQQAABBBBAIDUCoWA8+Ko1F3R3+eeZZq0+NRcm0QMlQE/05WFwCCDQSYHZc2+qdH/AvnuYVtMVNPeWtOJdOcFtKLB3mS194SULtlUO0gMPL7FzZ8+3Q48503+dmoL1+92+GxfeZdNmzDHlOlZvDjTyxoDOISGAAAIIIIBAZwWKXWZFv+Ktr+V0wbiLyoNyQfszVt9Z7ez0ToCenWvJTBBAIGKBYPVazd6z+EHTinhfKbgdXcc3khS8q10F68efOttmX3OzqT+1MXqHbe22b11sW44criIJAQQQQAABBFIjMMB/c4W5YNzF5mZaQS+6LLNlzY3UqgABequCnI8AApkV0FedNZJGhYJoPYU9OH/M7jv3cJoyabwpHTL2nRb+jLkCc5274Krppq9d63FyYzs4GgEEEEAAAQTaLOA/g+6Cch+cF90Kug/OB1hWy23mzWx3BOiZvbRMDAEEWhWYNX2yNazpp+sAABAASURBVJLCq9wKsIPzFYSHx6PAW9+lrs+2333rlfbovQsq6e5brvB965jweckrMyIEEEAAAQQQ6CnggvIut7cSnGe97ObKb8sCBOgtE9IAAggggECsAjSOAAIIIIBACgW6FJybC8qDlfOMl1N4iRI5ZAL0RF4WBoUAAgh0RmDV6lWd6biDvaah6xWrVtkLy160lVyfNFwuxogAAgiUBYLgPC95edpkLQkQoLfEx8kIIIBAOgUU7N10x0I75eyr7fgpX7FvXX+Xn8hNN/3W3vfPp9knJ11gX7n223b3ff/t9/PStEBTJ/7+8T/a+V+9xqZ86eu299gzbJ93z7CPHH61HXLoxTbuX2bYKdOvsutuvMn+8vTfmmqfkxBAAAEE4hcofQY9L8F5IX7QnPRAgJ6TC800EUAAAQks/fvffeCtYO+yM/9iP7vR7Nc/2sLWvLKlqm39iuH20pJd7ff/tbV9+7IV9qUv/o8PCAnUPU/sL3LWmyOf+cRt9v2rN9mdN5j97f9tZ8ufeqOtXFrKn35oO/vZdws297zn7ZhPfcMH63rDJfbB0QECCCCAQIMCVcF5t9vb3f5Mlhvk4fCaAgToNVnYiQACCGRP4Hd/+IMdffzVdsNVy3ywt3HNFv1Ocq0L3BUQnjH5Prv2+lv7PZ4DmhPQrevyPfu0u/2bI2tfLr1h0ldrXRsH+cBdwfpEd11/v+SPfR3eXB1nIYAAAgg0LVBUEF7rAXHar8+mK89QfdNQnNhNgAC9GwcFBBBAIJsCN/3Hf9iRE75p/3vPKKsnMA8rrF8xwq679Ck77bwr+Rx0GKfFsoLzz59xsffVKnkzzelNlBM/d0PqPpLQzFw5BwEEEEiPQKH8lWoDrFjUqAs98tJXrmWlXnMktSpAgN6qIOcjgECvAjcuvMvmLVhUd3r2+WW9tpWmiseefNrCc1d5+crVHZmGbmufPftee+2pN7bUvwL7u2/ZZF+59vqW2uHk7gI33rbIr5rLt3tNYyVd3/PP+bH9mc+lB3DkCCCAQEcFim51vKCV8mLRij4vuPGUgvSgXPD7s1HvJsdvBAIE6BEg0gQCCNQWWHTnYrvWBej1prQH6PcsftAOPeZMmzD5fJt9zc3d5q7yez46xb9ZUVsrvr1nX/5v9n+/3yqSDhRE/vDfV9sNLqiMpMGcN6Lb0hd845Gm7mqoRffKn3eyM790s3/ie6169kUpQFsIIIBAfwIFt4JecMG5WyHX7ewuGO9yQXvRslruz4P6egQI0OtR4hgEEGhKYPQO29ro7bfxadSIYf22MWrk8H6PSfIBWiFfWnUXwAH7jDGl6rnrzQoF6+2ah25t/+n31pg+rxxVnwrS51z+O4LACEAvvfLmlu9sCA/jsftG2Hdu/Y/wbsppE2C8CCCQeoGuopuCAnLlLigvlbXPpUrZBfAZqdesSK0LEKC3bkgLCCDQi8DcS062u2+90qff/OQ6e/TeBZW0cP5Mqw5cDxn7Tttj9517aSkduxWc602JWdMn269/PM8WXDXdJ81dFsEsdLt7O+4W0Hdn69b2ta/0/8CxYGz15mqTILBerdrH6Wvu/nBv9NdGvX3/O3/hDRRBkHoVoAIBBNogEATn3XIF5Equ/277g7LqlIJyOFedUnh/UFadUlAO56pTCu8PyqpTCsrhXHVK4f2uzG8kAgTokTDSCAIINCrw3R/8zFasWuNPC4JaX0jxy6cnjLO7b7nCxh821rYM3Q2gNyC0P5je408+HWzGlj/+17/aC3/dIpb2tYp+/6+fjaXtvDR6/6+fiezW9rCZ3kD5r/v+O7ybMgLtEqAfBBBwAkW/Ml4OZi37uZsyvxEIEKBHgEgTCCDQmIBWkBf97D5/klbRtdIcDmh9Zcpe+puDbncPpqTb4YPtuPIf/uQ+WxvD6nkw3r/9aR1PdA8wGsz1veW//uXzDZ5V/+F6A+WxP75Y/wkciUCqBBgsAmkRyH5QXuz2JkRarkuyx0mAnuzrw+gQyJzAAw8v8Q9QCyY2fdpxtuMO2wbFTOdLqz6f3o6J/vJ/noq1m41rt7C//F+8fcQ6gQ42/sjjf7TVf9861hGsWL4+1vZpHIHMCjAxBCIS8MFrcBt7sIIelMN5BuojYst9MwTouf8TAACB9gnoc9fnzJ5f6XDihHH+dvDKjoxv3H7n4soMdct7pZDSjfXLh9tfniZAT+rle+wPrKAn9dowrnwLMPscCQRBuILvLjfvoBzOs1LvptjI75q1623tOt5MDpsRoIdFKCOAQGwCJ8+YY8Eqsm73nj712Nj6SlrDuq0/mLs+i97f7fBRjP/pp5ZH0UyvbejJ8K+8/Jpts+UWdaegsUbOafTYEUMH+W6GDh5Y97ga7UPHFwq+G9t61JCG+wnGWGohntdXX95oQwZurGtsgweWJvO64YPrOl7zbzS9fuQQP9GBrq9Gz23k+CGDBvp+Rg6Lby4aj+/EvQzfotSfcu0PJ3cIvwi0U4C+EiRQdIG4lYPvovKgXDQrVpdd8N6tXExnvfXz88Rfn7F537nDPj11lh00fprtf9jnbb8Pfd5vTzv3avv9H//cTwt9V//yt7+3k865qq70yJK/9t1YB2sJ0DuIT9cI5ElAXy22pPxgND0Ubs4lJ+dm+tW39WvuUyaNz8zcd33TtrbF4AF1p2DijZzT6LGDB5X+p23AgELd42q0Dx2v9jUf9adyI+nFl5fF9oA4jSlI9Y6plbnU24eOa3RcOqfRNMi9AaB+lDd6biPHqw+lge7vLMhrna86EgLZEWAmjQnwGfTAa8XK1Tb++Bl27fW320N/eMJefnVFUOW377nvIfvUlIvtuhvuqOxvdEN3at77q4etnvSSW2BotP12HT+gXR3RDwII5Fdg0Z2LTSvIEtBD4fSVY+1YQVZ/nU56U0LvCmscwdzb9Zn7kSOGq9vY0pBRq2zEiK1s2fJ1dadgMI2c0+ixK9ds9N2sXb+p7nE12oeO7/JfaGv28or1DfdTGBDP0/X9xMsvO//DCFu3aVBdY9uw0S3fuPNeW7WhruM1/0bTqytLtzFu2lSMrQ+Nad2GTW4mZitWxzcX9eM7cS+r15X6U6794eQO4RcBBOoVyNhxxfBKeMbL9V6+Q963r51z8nH2jctPtwvOmGQHvesdlVOv+fbtdv9DSyrlZjc+fvj7TR+l7C3t9Mbtmm069vMI0GMnpgME8i2gdzNnz72pgnDS8UfamN13rpSzvKHgfNIpl1W+Tk4PxGvn3PfdP96H7w0Ztdp22XFnW7+hq+4UXO9Gzmn02I2bunw3Xe6/jBo9t5HjXfO+HwW3jZynY3fZaWcbunW8H0E48D071n1dyu812AZnp/HFkda5vxMP5l7iaD9oc1N5MsqDfXHkbhr+V/1oQ3mtflRHQgCBZAi0exRF3cbu/yepYMUulzJe7st30KBB9smPfcB+tGCWzZ11ih338UNdYL63ffJfDnaB+hl+X3D+3f/zQLDZdH76Fz5h+ihlb2n3f9ix6bbjPpEAPW5h2kcgxwL6KrFJp86uBKjBu5h5INFdA0dNPr8y91nTJ5s+e97OuX/yqP1t0LB1sXW59fZm22+b3HegY5t4BA3v/bY9bfe9I2iolyYGDNpob33rG3upZTcCCCCAQAwCPZos+uB8gHX5vGBW1CFB2RX9/qCcgXpNr5c0bOgQu+D0z9puu9YOjLWqPnzYUH/2Hx7/m8/z+kKAntcrz7wRaIPAubPnVx4Kp+70+aN5CxZZkHTbuwLZIGm1XcelPWk+mrvmMWrEMLtt/sy2B+fqe/+3v92GbhXPKq0CwHe/fwd1Q2pSQCvcTZ7a72mjdnzR3vymXfo9jgMQQAABBOIUcKvmPigv5cViKTetpLvtUm7up7S/73oX0LtzipX2XEDv23Gnl/Nih+s1klbS0C0G+9MHDSw9fNMXcvhCgJ7Di86UEWiHgILtexY/2K0rBa7XugA9SHpwnALZIM1zdd1OSGFBc9B8NHQ9EO62b13csVv6R7/hDXbUcbXfqdb4Wkk7veMV+/JJx7fSRO7P/ezR/2IjR0f/VWi6a2LSF99he4/ZM/fGACCAAAKdFChWgmmNohSEWzmYTlwewbishZ9nnnvRPyxOTez6ptYXAF59baW98OIr9tryVVYsXQg1nYpEgJ6Ky8QgEUAgDQJ6w0FvPmisCs4XXDXd2vVAOPVZK5099dO21W7P1Kpqep9W5aec/D4bOXxE021wopk+HvDJz7458o8h7Pm+VTbxqOx8UwB/KwgggEB6BVxQ7m9jd3kQrAflcJ6J+t6vVH813/ref1YOOewDB1a2m9346GfOtkM+cZq992Mn2ds/cLwd/umz7KYf3m26m7PZNtt1HgF6u6TpB4GcCSgw/fWP59ldt1xRd9LntNPMtOinv+w2fK2kTzp1tvWW9Bn9bifEUNAq+tw5H480SP+nj4yy8Yd+OIbR5q/JKccfbWM/viqyIF1vnsyYfjRvnuTvT4kZI4BAAgVKC7cuOFcwXn37ucrVK9YqZ6C+2Utw13//zr7/o1/40/feczd77/57+e0GXvo99KlnXrBL59xkR3/xIr+q3u8JHTyAAL2D+HSNQNYF9FVqCtTrTWn3WLFqTWUKS59fZg88vKTP1K53cT92yCEWRZCuz52//eDlds6Zx1XmyUZrAroL4YoLvhxJkK7g/MTT38qt7a1dEs5GAAEEohOoDrq1Qp71chNy+k700y64xp+ph8R99bwvWqGgz9f7XQ297L3Hm23ml06wG+acY3pa/E9v+op9b955du4pEy34WjUF6qecP7ehds3aezgBenu96Q0BBDIsMPeSk013AdSbRo0c3jaNVoN0BX+TvrSVXXvVF/2t2W0beA46iiJI3+N9q+yr33i/neRW5HNAxhQRQACBVAhoBb1obgXdBebmc7Msl63Bn0eW/NU+PXVW5ax//+oZlUC6srOBjT3fuqsd9ZH32357v9U/LX7nHd9gWpE/9sgP2u3fvtje+uadfGtaQFn28mt+OxEvoUEQoIdAKCKAAALNChwy9p2mr1KrN+kOg2b7auY8Bem33fJF2+fDL9qQUavqbiII/r580gkE53WrNXZgEKSfdP6O/uMIuluhnhb0QLiPnLjWvnHtiXbo+/6pnlM4BgEEEECgbQIDTEG6ueC8q2juJ+tlN8U6fx985E92wmmXV46+/uvTbd+3v6VSjnpDq/OTjv5wpdnHnni6sp20jagD9KTNj/EggAACCFQJ7P/2t9st37zEZs7Z1xTY7fSOl/1XsQ0YtMkfpVxB3/A3vGy6nf2Es0cR/HmZ+F8UpP/rxONs0W1ftmkX72D7HPaibbnLc/7z6bomQdKbK9r/oYlmX1/wLrvygrN448T4QQABBJIn4IPz4gDzwblbRc96ud4r8ItfPWQTp11qq9esNQXOt1x3vh2475h6T2/6uO2326py7quvrahsJ20jZQF60vgYDwIIIJC5f+R+AAAQAElEQVROAT3kTYGdgsEbfnCUHTa+9HVsyq9yQd/CRcfbwu+eZ6yat//66unuCtRvmX+J3fmTL9mChQfZ/FvHmq6L0r/dPM7uufs8u/qyU1g1b//loUcEEECgboFiJSjvfpu7lfdnr75/Gj0Mbuo5V/sDt379KLvlG+fbO/Z4sy/H/fL0s3+vdLHzTttXtpO2QYBefUXYRgABBHImoFXbvcfsaW/eeVc/c+X//L5/qpT9Tl46JrDDdtuZPprwkYM/YLouSu/Zd3+e0t6xK0LHCCCAQP0CRX9bu4JznVOwLj2t3Qrl294HlPOgXEh9vWbZW9q0qcu+Ou8Wu+hr3/GH7PGWXey2+RfbbruM9uX+Xl56Zbld/PUbfJr77R/2OFzfjKPPlveoKO9Ys3a9fevmn5RLZrvvWlqYqOxI0AYBehsvBl0hgAACCCCAAAIIIIBAXgQKPYLwcNCerXLv1/XWH/3CFnz/zsoBUyaNt7/+33P224ceq5mefvaFyrHaWL5ild1yxz0+aRVe+6rT839/2X+t7YQTL7A7fnafPf7n/7O169bb6jXr7DcP/tGOnTLTnnnuRX/KlM8eYSOGD/XbSXwhQE/iVWluTJyFAAIIIIAAAggggAACCRHoFnyXb2u3YAU9g2Xr42f1mrXdaqede7V/SJweFFcr3bLonm7H11t47Imn7JzLvmkf/9x5tt+HPm8HfPgL9rnTv2J/+sszvgk91X3ycR/120l9IUBP6pVJ3LgYEAIISEC3UD37/DJtkhBAAAEEEEAAgT4E3Aq6bmuvDsYzXe6dYsCAQu+VNWoGDOwepg4YsLk8ePCgHmfoAXCf+9ThprxHpduhh9FNn3qs3Tj3HNtiyGC3J7m/m2ea3DEysjwIMEcEUiCgzza956NTbNwxZ0Yy2hsX3mV7HTyprnT/w0si6ZNGEEAAAQQQQKA9AkUF48GKufKMl/tSPeGYw+3RexfUnc784tHdmttlp+0r597zg693q1PhdaNG2Olf+KT9/Ptfs18svMq+/28X2rWXnmrzr/iS/Zfbd/9/XmcTJ4yzQQMH6vBEJwL0RF8eBheVAO0g0KqAVs3PmT2/1Wa6nb9i5epuZQoIIIAAAgggkCUBt4IeflCcLw/o9bPp/ivZLK31nb92hULB3rDt622vt+1qB793H3vP/nvZG9+wtRUKja3gWwd/CNA7iE/XmRFgIhkV0O3s02bM8Q8d0ar50hhvbZ8+9VibNX2yT3MvOdmuv2p6tzRm950zqsy0EEAAAQQQyKZAUbe2m4J0l8p5wedFF6C7fRmrz+ZVbP+sCNDbb06PCDQowOGdEtAK9z2LHzTd2h73GA4Z+04bf9hYn7R94D5jrDptOXJ43EOgfQQQQAABBBCIVMAF4V0uKSgv397e5YPyqhXyTNVHipfbxgjQc3vpmTgCZQGyXgV23GFb+/WP59ldt1xhC+fPNAXOvR5MBQIIIIAAAgggUCXQ5YNys9Jn0QeYLytA9/vLZXd8VurdVPiNQIAAPQJEmkAAgd4F0l6jlWsF6nvsvrMppX0+jB8BBBBAAAEE2iXgVs9dQG5aQfefPVfZ3E91XgiVXbHb8Wmq19hJrQoQoLcqyPkIINBJgcz0PW/BIgvSojsX22NPPp2ZuTERBBBAAAEE8ihQ7DUol0Z1kJ6NsmZBal2AAL11Q1pAAIHMCvQ+MT1ArvfaxmsUlF/rgnSlc2fPtwmTz7dDjznTtL/x1vo+Y+CAgoWT22X6UR6ui7KsPpSibDPcVqGg1QazAS4P10VZ1jyUBg4s9PCMqp9BAwoW/ETVZq12gm4GxGnmnNozl5JZoVCI7brI0Mo/A0rdub83q9lf+TAyBBDIpcDmINzf3l61Mp7Nci4vcuSTJkCPnJQGEUAgDwJ6gFzL86xqYNSIYTZ6+22q9pgtfX6ZKViPOkjffquhFk4jhg7yfSsP10VZ9p24lyjbDLf1uhGDXQ9mQ4cM7DHP8LGtlBWYq6Ntt9witn5eP3KIurAtBg+IrQ8ZDB5U+s+BrUcNia0fOWkyclOfcSVdd/Wjv4O4+lC76kNJ/2aCXPvDSXUkBBDIp0CXW0EvFgum3FxwrjzLZeMnEoHS/yJH0hSNIIAAAgg0IvDpCeP8A+gevXeB/eYn19ndt15p2tZD6cZ/6H2VprSq3syKfaWB0MamTUULp6L7jwgdpjxcF2VZfShF2Wa4rS79F5DrRHm4Lsqy68L/RtlmrbZ8J+6lVl1U+2TlujDlUbVZqx31oVSrLqp9moP6UB5Vm7XaUR9K+jcT5H0dp2NICCCQMwEXnPv/H5GXPGeXN67pEqDHJUu7CCCAQD8CwQPowoftuMO2NuvsE+2Afcb4Kq2kL4nwM+kvvLrWwmnl2o2+L+Xhul7KPdqo5zjfiXup59hmj1m+eoPrwWzthk1NjbHefhWMqaNly9fF1s8rq9arC1u3oSu2PjTfDe5NG3X08sr1sfUjJ/UhN/UZV1rrrrv60d9BXH2oXfWhpH8zQa794aQ6EgII5FPAB+du5TwveT6vcvSzJkCP3pQWEUAgowJRrmLXQ6TvRQ+OezzCAD1oM9k5o0MAAQQQQCDtAgULgvPSzV1ZL6f9eiVj/AToybgOjAIBBFIgEPXnzlMw5ewOkZkhgAACCCAQs4CC8mLV7e1BWbm5/cqzVB8zZ26aJ0DPzaVmogggkDaBZ59fVhmybnuvFNhIvAADRAABBBBAQEF4sWhuFb28cu6CcpWD/UFe7GV/6uq55JEIEKBHwkgjCCCAQHcBBdd7HTzJlPR1ad1rzVQ/+5qbe/2+8wceXuK/F13n6Qnv+5c/j64yKfcCACCAAAIIpECg6IJz4zPoxk9jAgTojXlxNAII5EhAnzm/Z/GD/rvI9VVn1Q9qu3HhXZX9CrbDLNX79JC3WvVqQ993PunU2T4YVx/ap69W077gnJOOP9L0QLmgTI5AvAK0jgACCCAQjUB55dwF6bqd3VweBO3ZLBs/EQgQoEeASBMIIJBNAX3mfNqMOf67yBU0hwN07VO6487FPQAauSVdq+XXLljk+9GqugL1oMGTJo23iRPGBUVyBNIvwAwQQACBnAgoCC+GgvJicDu725+1+pxc1tinSYAeOzEdIIBAWgVGjRxuepJ6f2nM7jv3mKLOVXAdnBs+4MB9xtiCq6b79nX+6O236XaIvmJt1vTJNsUF6N0qKCCAQJ8CVCKAAALJEShYscvMB+kuNxeUF4uhsttf1H6Xp7/e+IlAgAA9AkSaQACBbArotnIFyf2lQ8a+sweAzlVwHZzb4wC3IwjCb5s/0+6+9Up79N4FlRQE7+4wfhFAIDkCjAQBBBCoW0DBuVUH30EQntHc+IlEgAA9EkYaQQABBBBAAAEEWhXgfAQQyJaAW0EvakYF0+3spmA902XjJwIBAvQIEGkCAQQQQAABBBBIvAADRACBtgooKC9WBeWV29uLGkYpaC9mqF6zIrUuQIDeuiEtIIAAAggggAACuRcAAAEEwgKF8mfQB5TzoFzKTcF5lz6Tno164ycSAQL0SBhpBAEEEEAAAQQQQCBGAZpGIHUCxWLBjVnBeLGUV8quqOC8Us5GvWZFal2AAL11Q1pAAAEEEEAAAQQQSLUAg0cgBgEXgBcVe7tgXLe7W9bLMRDmsUkC9DxedeaMAAIIIIAAAggg0D4BesqlgILzogvOiy4wN5/rdna3op7RsvETiQABeiSMNIIAAgjUFnj2+WW26M7FtuTJp2sfwF4EEEAAAQRaFOD0ZAqUgvMgKM9+nsyrkL5REaCn75oxYgQQSJHAubPnm9KNC+9K0agZKgIIIIAAAhUBNpoUKBbdiW61vHteeiBc5Xb3DNW72fIbgQABegSINIEAAgiEBR5zK+bTZsyxBx5eEq6ijAACCCCAAAIVgQxv+OC74JbOdVu7m6cvu9wKtvkz6Rmq19RILQsQoLdMSAMIIIDAZgGtlO918CSbMPl8u2fxg5sr2EIAAQQQQACB9gt0sEetnPtFdPdSNLdy7nMXr7vcXJCetXrjJxIBAvRIGGkEAQQQKAmMGjncRm+/jU+lPbwigAACCCCAQFYF+ppXsRKEF6wUjCt3ye8Pchew+3KQB/uDPNgf5MH+IA/2B3mwP8iD/UEe7A/yYH+QB/uDPNgf5MH+IA/29yVBXSMCBOiNaHEsAggg0I/A+MPG2t23XunTo/cu6OdoqhFAAAEEEEAgqwIKyq28cm5FF8i6ZOVgfHO5tLK+uewCXx3nUrFolqbz3WD5jUCAAD0CRJpAAAEEEEAAAQQQQAABBLoLuGC7y+3xnz0vuI2klaMej5sivy0LEKC3TEgDCCCAAAIIIIAAAggggEB3gaILzovlFXOfZ7zcffZmxo6mBAjQm2LjJAQQQCC9Aq8fOdjCaeiQ0v8cKA/XRVkO1KJsM9zWsC0G+m6GDBrYY57hY1spF7QY4np63Yienq20W33uqGGDXA9mAwcUYp3L4IEF38/IoYNi60dO6kRu1XOMelvXXf3o7yDqtqvbUx9K+jcT5NX1wbbqSAggkE8BH5QXzYrVQXoxu+V2X+Ws9lf6L7Kszo55IYAAAgj0EBi+xSALp8EDS/9zoDxcF2U5GEyUbYbb2mJwKUAf5ILOcF2U5QEuaNZ8hg4Z2MMzqn6yNBc5yUtuUfnUakfXXf3IrlZ9VPvUh9Lgfv7t6BgSAgjkU6D0GfSCf0CclYP0Su5vezf3k516N5ks/XZsLqX/IutY93SMAAIIINBugVdXrrdwWrt+kx+G8nBdlGXfiXuJss1wW6vXbnQ9mK3bsKnHPMPHtlLu8l9ia/baqg2x9bNi9QY/l42birH1IYMNG7t8PyvXbIytHzmpE7mpz7iSrrv60d9BXH2oXfWhpH8zQa794aQ6EgII5FXABd/+/72G8urgPFP1eb3Ozcy793MI0Hu3oQYBBBDIpMDqdZssnDa4AFCTVR6ui7KsPpSibDPc1vpysLnJBdDhuijLpZURMwVoUbZb3da6Ns3FUemy2Fr3pkZ1/1Fuy0mdyC3KdsNt6bqrH/0dhOuiLKsPJf2bCfJa7auOhAAC+RSofAbdBeFFraAHebF8m3tQDucprc/nVY5+1pEE6NEPixYRQAABBBBAAAEEEEAAgfQKFBWUF8vBeA7y9F6pZI08DQF6ssQYDQIIIIAAAggggAACCCDQj4DuGLJykJ6H3PiJRIAA3SJxpBEEEEAAAQQQQAABBBBAoEqgsPkBcV3anfWy5khqVYAAvVXB/s6nHgEEEHACy1eudq/8IoAAAggggEBeBPxn0MsPhCtqJd0F6cUMl/NyXeOeJwF63MIxt0/zCCCQLIF7Fj9o586e79O0GXMqg3vgocf8vqCuUsEGAggggAACCGRSwAflRXOr6KWV86KC9GJ2y5m8iB2YFAF6B9BT1CVDRQCBBgV+7gL0RXcuNiUF68HpK1at8fu0X+nZ55cFVeQIIIAAAgggveq8wgAAEABJREFUkEGBogvGrRyU5yE3fiIRIECPhJFGmhPgLASyJzBxwjibNX1yv2nHHbbN3uSZEQIIIIAAAghUCZRWzq1WkN5l7idr9W5K/LYsQIDeMiENJFaAgSHQAYExu+9s4w8b22/qwNDoEgEEEEAAAQTaKKAV9GL5M+dWzoNysRy0B+Us1LeRNtNdEaBn+vIyuTgFaBsBBBBAAAEEEEAAgd4EqoPvrmLVZ89DwbqC8yzU9+bA/sYECNAb8+JoBNolQD8IIIAAAggggAACKRZQgG5upVzBt/KgXHTBenU5K/XGTyQCBOiRMNIIAmkTYLwIIIAAAggggAAC8Qr08RnzSpCuEWTlOM2F1KoAAXqrgpyPAAI9BdiDAAIIIIAAAgjkXEAr5UV/O3vBSSgIL5a/ci0oB7e9B+V017tJ8huBAAF6BIg0gQAC7RWgNwQQQAABBBBAIOkCWiQvuhf3a11dLhg3BenKzXRbu/ZnqT7p1yMt4yNAT8uVYpwIINAuAfpBAAEEEEAAAQRaFlDwbYVSUG5WzoOyX1k3s6Bs6a83fiIRIECPhJFGEEAgywLPPr/Mzp093w495kzb6+BJlTTp1Nn2wMNLGpx698PnLVhkaqe/NG3GnO4nUkIAAQQQQACBhAsUyivlyrVertys6ILxrlL0nrH6hF+OlAyPAD0lF4phIoBAZwQUnCt4XnTnYlvqAvXqUSg4D+qq9zeyfb8L8NVOf+mexQ/W1yxHIYAAAggggEAiBHwQXnQBuUvmVso3l/0OF5y7XL8uZaE+EegZGAQBegYuIlNAAIH4BLRyHgTm4w8ba9dfNd2niRPGVTq91q2CK5Cv7GhiY9SIYXbAPmNMfVQn9XPSpPGmZAn4YQgIIIAAAgggUK9AacVcR+sz52ZBOZybC9bN/YT3B+W01Lsp8NuyAAF6y4Q0gAACWRUIVrU1PwXPs6ZPtgNdEK00feqxpqS6pW5l/caFd2mz6TRq5HBbcNV0Ux/VSX1McQG6UtONp+dERooAAggggEBmBHxQ7lfO3ZSK5WA7KAfBelDOQL2bJb8RCBCgR4BIEwggkE2Bn1fdVl5rBVur26N32NZPvvpYv4OXBAowJAQQQAABBNopUDD/UXMfjPv72F25lPvb3d3+bNW30za7fRGgZ/faMjMEEGhRQCvoaiK4/Vzb4aTVdO1b6lbRl69crU1SXgWYNwIIIIAAAlUCCsIVgCs3v1JedAF6wbqXLVROb33V1NlsQYAAvQU8TkUAgWwLPPvci36CO75xO5/XetmxvIKuuiVPPq2sqbTCBfd6YJw+y65EsN8UY6ZPYnIIIIAAAmkTKLiAXGPenPvb3m1zWQG8VZXTXW/8RCBAgB4BIk0ggEA2BVasWuMnps+H+40aL33V1Ti8113q6/hTZ9u4Y8706T0fnWKHHn2G6QF0BOu9slERnQAtIYAAAghELKBgu+hXzs0F6gW3Uu46qJTNl7NU72bHbwQCBOgRINIEAghkW6CvILyvulZVlr7wks1bsMgUuGtVvdX2gvNHbzPMwmnUsEG+Wnm4Lsqy78S9RNlmuK3XjxziejAbvsWgHvMMH9tKeeDAgu9n+62GxtbPtltu4fvYYvCA2PqQgdpXR+pP5ejTMJOT+pBbHO0HbQ5311396O8g2BdHrj6U9G8myGv1ozoSAgjkVaDgAnN95tzKeXVZJtVlHVddTmO9xlx/WrN2va1dt77+E3Jy5ICczJNpIoAAAk0LbDlyeNPn9neivlJNT20Pvr5Nucp6ars++67zdet8q0+JVzskBDIrwMQQQACBBAros+bFYqFqpbxoRQuVM1Tf3yV44q/P2Lzv3GGfnjrLDho/zfY/7PO234c+77ennXu1/f6Pf+6viVzUE6Dn4jIzSQQQSKqAAnQlPWwuSCrrqfGXnn1iZdiLfvrLynarG0tfWmPhtGLNRt+s8nBdlGXfiXuJss1wW6+uLL0bv3rdxh7zDB/bSnnTpqKbidkLr6yNrZ9ly9f5PtZt6IqtDxmofXWk/lSOI8lJfcgtjvaDNnXd1Y/+DoJ9rea1zlcfSvo3E+R9HadjSAggkDeBgls515zzkmuutZOetTP++Bl27fW320N/eMJefnVF5UBt33PfQ/apKRfbdTfcUdmf1w0C9LxeeeaNAAJ1C/R1e7me3l53Qw0eeMjYd5qSTtNn1B9r4SF0aoOEAAKJFGBQCCCQUYGiex+3WPWZc18OVtBVp5Sh+nov4yHv29fOOfk4+8blp9sFZ0yyg971jsqp13z7drv/oSWVch43CNDzeNWZMwII1CUwZved/XFLnnjK57VeqoP3Haue6F7r2Gb2xXl7fTPj4RwEEEibAONFAIFOCRRdMF5UVO4GoCzrZTfNXn8HDRpkn/zYB+xHC2bZ3Fmn2HEfP9QF5nvbJ//lYBeon+H3BSff/T8PBJu5zAnQc3nZmTQCCNQjMLoccGv1ujoQrz432K/Pi8cRoAftq8842le7JAQQQKBpAU5EAIFeBRScl4JyM62k+3Kx4G97L7qVc1/2QXw26nuFcBXDhg6xC07/rO22646u1PNXq+rDhw31FX94/G8+z+sLAXperzzzRgCBfgU+OPadlWPuuHNxZTvYeODhJaak8gcP2k9Zt6SHu006dbadO3u+1XrIm4Lv4PxuJ5YLqlNS8YB9xhir6ZIgIYBAngSYKwJpFqgE50EQrtxNqOb+ogvSU17vptbS79AtBvvzBw0c6PO8vhCg5/XKM28EEOhXQA9rC1bRr12wqBKM68T7XXB+jgu8ta2kY5VXp3sWP+jPWeSC+5+77eo6bSvoVwCvpGMVsGu/Pmuuc/prX8eSEEAAAQSaFuBEBGIV0G3t6kB5kExBuILxcjL3E9QptxTXWws/zzz3YuXBcbu+aYcWWkr/qQTo6b+GzAABBGIUuHT65ErrCqT3OniSHXr0GXa8WxkPHhA3ccI40wp35cDyRhDcl4u9ZlolnzZjjo075kxT+xMmn+9X3YP2T5o03mq9AdBrg1QggAACCCRAgCHkXcDF4KWvWHMQCr5LZX3VmlstdwX3m6l6N82mf7/1vf+snHvYBw6sbOdxgwA9j1edOSOAQN0CCrwXXDXdqoPtpS+85M/X584VPE+feqwvh190S/ro7bcxpVqfHz/isLE+sFc74XNVVp9qf4oL0FUmIYAAAgggUBFgI/ECCsqtvCJu/jPn5n5Kn0HPYtlNrqnfu/77d/b9H/3Cn7v3nrvZe/ffy2/n9YUAPa9XnnkjgEDdAgrS777lCls4f6Zd74L1IP3mJ9dZX8GzviLt7luvNKVZVSvxQccK2hX8q527XPtBu0GuPvtqP2iHHAEEEEAAgagFaK91gaIVyivk+cibEXvoD0/YaRdc40/VQ+K+et4XrVAo+HJeXwjQ83rlmTcCCDQssMfuO9uB+4yppIYb6OMEBevVbWu7j8OpQgABBBBAIM0CuRh7aQVdt7MX3Yv7dZkmrqe3m9vOWr3m1kh6ZMlf7dNTZ1VO+fevnmE7vXG7SjmvGwToeb3yzBsBBBBAAAEEEEAAgUwKJGdSXQrErbSCrlFlvaw51pMefORPdsJpl1cOvf7r023ft7+lUs7zBgF6nq8+c0cAAQQQQAABBBBAAIHGBOo8WsG4ueDcr5QXgiC9YFktW50/v/jVQzZx2qW2es1a023tt1x3vh2475g6z87+YQTo2b/GzBABBBDoVeD3j//Rfv3Q7+yRJX/0xzzy+G9t0d0/9fteWPai38dLZwTk/7+P/dFu+o//sG9+/1a79tu32nU33mR33/ff9pen/2YrV6/qzMDoFQEEEECgToGCdZWi8Rq5mqhdby6oD4L7dJ1v/f7oYXBTz7naH7f160fZLd84396xx5t9mZeSAAF6yYFXBBBAIDcCCvz+/ZZr7db//LQNGzbJdt35C7bf3qWnp+73jt/ZER86y+97/Kkj7Xs/OcsHhASD7fvzUAB+2nlX2kcOv9o+9fEf2EnH/q+dM/kpm3v+83b12cvstEm/tQnjr7fxR33Frvi3b9rvy2+utG+E9IQAAgggUI9AzyBbZxVKwXrRXF5VDgfl8dW7fl3j7jfq8Wk2vaVNm7rsq/NusYu+9h1/yB5v2cVum3+x7bbLaF/mZbPAgM2bbCGAAAIIZF3gG7fcYv/9u6PtU0d80044+iHbZ69Vtvuua7tNe+SITX7fhw9+xSYf82N7+5jT7Vs/mGYK7LsdSCFSAfl+8awL7Ev/+j/20+sH2cql29nal7e0ro2DuvWzcc0WtvrvW9szj2xt8y9ebSd85ma74bZF3Y6hgAACCCCQDAG/gF4Jvq10e3uGy2a13W/90S9swffvrFTqW2r++n/P2W8feqxmevrZFyrH5m2DAD1vV5z5IoBAWwSefX6Z3bP4QVt05+JK0r62dF6jk6V//7vNuPrL9oGxF9jxn3jBdnjDhhpH1d6lAP6cqb+1ex+YzGptbaKW92rV/PNfuN7uvWlrH5Q30qAC+a9M/5Od/9VruO29ETiORQABBGIW0Ap1sRKMF9zKtQvQg3L5M+lZqu+LU583r66fdu7V/iFxelBcrXTLonuqD9+8nYMtAvQcXGSmiAAC7RVQUH7U586zaTPm2Lmz51fSuGPOtNnX3NzewZR7m/e9K+xfP/PDhgLz8qmV7IRPPmmvrjzDfv3QA5V9bLQuoFvUZ3z5p/b4b7doujGtqi+8dp2dedFXmm6DExFAAAEEohYouBXzoms0L7mbai+/AwY09t3mAwZ2JkztZfht3Z3fmbeVmc4QQCAvAjcuvMsH5CtWrfFTHr39NqY0asQwX1Z9u4N0PWTsn9//Uxs5osuPoZWXD3/gaVu/8Qpud28Fsepcfbb/0itvtteeemPV3uY2uzYOssU/HGHXXn9rcw1wFgIIIIBApAL6vvOiXzEvmvKsl/vCO+GYw+3RexfUnc784tF9NZfWurrGTYBeFxMHIYAAAv0LLF+52gVHt/sDFZDfdcsVdvetV/p027cutjG77+zrFKTf//ASvx33i25tX7Z8ru27V3RP/D78kD/Yf/xiZtxDz0X7t//0bvvDvVtGNletpP/bV/5sejJ/ZI3SEAIIIIBAUwKloFynagW9dHt78Jl05Vmr10xJrQs0H6C33jctIIAAApkSuOPOxRasnE/8xIdsxx22rcxP23MuOblSVpBeKcS4oVvbJxz+l8h7+Kd3/dY/3T3yhnPUoL4q7Zqv/cYUVEc57fUrRtiVV/40yiZpCwEEEECgCYHqIDwIxouundr7gyDeBfLuoKJbea99XHLr3dT4jUAgsQF6BHOjCQQQQKCtAkuefLrS38QJ4yrbwYaC9AP2GeOLeoCc34jxRavnb9/j55Hc2h4epp7+/rdnfxbeTbkBgR+61fMobm2v1eWTvzdW0WvBsA8BBBBoo0DR9RXc1l7Kq4Nr3fausnIF58pVdskH50FZeTrq3XT5jUAgrwF6BFV61GEAABAASURBVHQ0gQACCHQXuP+hx/wOfeZ8y5HD/Xb4JbjNXfsfe3JzQK9y1Ome395tBx3wWtTNVtrbcYf7KttsNCagz57f9eOnGjupgaP19WwP/+HxBs7gUAQQQACBqAU2r4AHQbZ6CIJt5dXBeKlsleC8VC6GykmuN34iESBAj4Qx3AhlBBDIo8DSF17y097xjdv5vNZLdeC+YuXqWodEtu/VFQ/EsnoeDHCHN6w33aYdlMnrF/jL00/Z3//W/FPb6+np//4a799XPWPgGAQQQCDPAqXgOgjCS3nw1Wubg/fS/qCc5vo8X+so506AHqVmu9qiHwQQSK3A6KrPpcc9ia7iMw13sfh/1trsi1+pK91243P2jWuusiu/MqvudOGFF9qFLjVyTqPHzr70Yt/HrEtm1j2uRvvQ8TNnXuT7ueLySxru59+u+bqteOXXtm7jf8WWHlj8o7rHdcnFpbl85bLG5yKLepKcLnTXXm71HN/sMbru6kd/B822Uc956kPp1/f9j/93tsWgATZq2KAeyVfyggACuRQoBd0uAC+Wpq+ytqpzVVWX01yvsZNaFxjQehO0kDUB5oMAAq0J6LPmrbUQzdlFW153Q2PfP9SUfIB+yas2u4604N/+bjd9+9/tay5ArzdddNFFplTv8c0cd7kLMtXHpZdc3NDYGu1Lgab6ueLyWQ33s+iWm2zt2ntt/cafx5b++ODP6x7XJRfP9Nflq7MvqfucRr3kJC+5NXpuI8fruqsf/R00cl6jx6oPpV/f90v7p3/6Jxt36CE2avjgHqnuf4QciAACmRMIgm/lpZVxs3Cu4Dwr9Zm7gB2aEAF6h+Bz3C1TRwCBNgkUbUXdPY39p2E2fcbrG05HfupjdvqXz607XXDBBabUyDmNHnvW2TN8H+fMOK/ucTXah44///zSXM48q/756zyl8cccZ0OHHmxDBn0wtjRyq/fYF6aeWpfBjPPO92Zfmj6jruM1h0aTnHTt5dbouY0cr+uufvR30Mh5jR6rPpR03hnu38B+B77PVqze0CPV/Y+QAxFAIHMCCr7Nf4bc3E/pM+WW4bLxE4kAAXokjDSSHAFGgkDnBZb38dnyFX3UdXrkPkg/byubXmeaevo29s8f+6wpOKk3XXjhhXahS/Ue38xx0885z/dx7ozzGxpbo30p0NRczjxrRsP9vPfQD9lg+5BtMeifY0u7jHmPnX/hpXWNbcZ5F3izL7s3Nxp1qPd4OclLbvWe08xxuu7qR38HzZxf7znqQ0nH7/eusbZizcaaqdP/rukfAQQ6KVAor5iXcnPBeWkFPatl4ycCAQL0CBBpIkcCTBWBPgRGjRjma5c+v8zntV6eraob1cuT3mud18y+AYWdmjmt7nMe+uNI2/tte9R9PAduFnjDttvZoGHrNu+IYWuPvbaNoVWaRAABBBCoV0DBuI4traSXbm/PcllzI7UuQIDeuiEtIBCZAA2lW2DMW3bxE1jSx9enVa+gx/1Z9UGFd/nxxPXy/N+HmALNuNrPcrt7v21PG7pV/c8IaMZizF69f5tAM+1xDgIIIIBA4wJBkK48+Ky5WlE5nKe9XvMhtS5AgN66IS0gkBYBxhmzwJjdd670cP/DSyrb1Rs//+X/88UD9hlj1V+55ndG/LLHmw+yhx8dEXGrm5t77oVdbeTw+Nrf3FP2trZ3K+jv+2B8AfSQUavsLW+O9w6K7F0VZoQAAghEK1AKwjffzl5aSd9czlp9tHr5bY0APb/XnpkjELEAzU2cMK6CcPk1N1e2g415CxbZilVrfFEBut+I8eUD73qX/e9jY2Lp4SEX+O88+oRY2s5Lox/96D6x3ea+59jV9u59988LJfNEAAEEEipQHYxrfbxgm4P0UnlzkF4qp7s+oZchZcMiQE/ZBWO4CORWIAUT1y3r4w8b60eq29wnnTrbFt252KdzZ8+3a12Arkp9Vr06mNe+uNKQAUfZ838fHHnzv/l/4+yzHzvMRm8zrKEUDKTR8xo5/vUjh/huhm8xqKGxNdKHjh04sOD72X6roU31I7+93rPetxHly/A3vGxfm3m8vfVN29Y9ri0Gl/5zYNstt6j7HBk0kuSkecqtkfMaPVbXXf3o76DRcxs5Xn0o9XeOjiEhgEA+BbpK0bZ/UJz5B8QVTWF4aX/B7Vcp+Gx6qaw9aa03fiIRKP0vciRN0QgCCCCQXoGoRn7W1GMtWB1/4OElpsBcSYG6+hi9w7a24OqzY7+9XX0pffGYY+yG2z5gK1dF9//uF/7nP9hnPnaWmie1KDDz/I/ZVrs902Irm08fMGijnXb2nrb/29++eSdbCCCAAAIdEii4ILzUdSlWD8rh3KpW1nV8Wus1dlKrAtH9F1urI+F8BBBAIAMC+lz5gqum25RJ432gPnr7bWz09tuYPp+uVXPVabudU50++Uqbd8M/RxKkazV+2y1PttFveEM7p5DZvvQxhLlzPh5ZkP6mvV+xKRM/kVkvJoYAAgikSaBL6+UFM+V+ZbyqrHlov1tYz0y95kRqXYAAvXVDWkAAAQR6CJzkAnQF43ffeqUp3TZ/pk13q+s7uhX0Hge3vKPvBkaNGGFRBOk/+Mm29sBDF9gRhxzRd4fUNiTwsUMOsVaDdH1l2z8essJ+dvtZpuvd0AA4GAEEEEAgJoGCWxlXaF7wQbi5aLzol9KzWjZ+IhAgQI8AkSYQQACBpAsoaAuC9Cf+NrSh4T7/98H2nYX72eHv+7F9+l+ObehcDq5PIAjStxnzN9Nt6vWdVTpq5OgXbebX9rZf/mQWdzaUSHhFAAEEEiGgFfJioRyMl/OiC9K134JyOa+ULXR8iuoTgZ6BQRCgZ+AiMgUEEECgHgEF6bNO+YY9/vjlNnvenqYnsff12XTdzv7Te7eyJX+aYScf+4PYgr96xp6HYxSk3/ezmXbE54v+lnd9VVpf8x669XLTqvmP7jjepk46sq9DqUMAAQQQ6JBAacXcyivpVl5Jt0o5a/UdYs5UtwTombqcTAYBBBDoX+C4f/kXu+zUH9vIwd+zXyy+yAXr77bv/OCd3dJ3bzvCHv/Tdfb+fX5qRxwysf9Gk3tEqkamz/Z/58rz7A+/vdy+fcsH7LNfGmL/eIgC8c3p/R9fb1Mv3Mr+82fH+lVzHgiXqkvMYBFAIEcCXW6uxeAz6D53O3xetNJ+F6iHym4B3Qfxaax3s+M3AgEC9AgQaQIBBBBIo4ACu0//y3EuWL/ZTj5uYbd00qe+blrRVcCYxrm1b8zx9KS7HeQ/d+bpLgi/tFv68U3n26VnfYEntcdDT6sIIIBApAL+I+cu6u4qumZdML65rB0uQPdZofS097TXuyny27oAAXrrhrSAAAIIIIBAPAK0igACCCCQWgF91ry0Eu6icBd8d7nofHPZBeUWrKRnoz61FyphAydAT9gFYTgIIIAAAgi0S4B+EEAAAQTiFfCfMXfBuc9dVz7PcNlNkd8WBQjQWwTkdAQQQAABBBCoKcBOBBBAINcCpc+gu5Vyt0BeWjk3K+qp7Bkt5/piRzh5AvQIMWkKAQQQQAABBNolQD8IIIBAwgWqVso3fwbdRed+vxu7z13ZbWai3s2D39YFCNBbN6QFBBBAAAEEEMiaAPNBAAEEWhTo/plzs0o5+Cx6kJsL0l2wnvb6Frk4vSxAgF6GIEMAAQQQQAABBNolQD8IIJADgULBSp85z0meg0vajikSoLdDmT4QQAABBBBAAIH2CdATAggkQKC0Il4or5xnP08AeSaGQICeicvIJBBAAAEEEEAAgXYJ0A8CCNQlUDAruv8z5cXSbeyZLteFwkH9CRCg9ydEPQIIIIAAAggggED7BOgJgYwI+BV0Nxc9AK7ognSfdyv7cN2tsLtAPgP1bmr8RiBAgB4BIk0ggAACCCCAAAIIpEOAUSLQNgF9Bl2dueDbrZ+bX0k391MpF7S+bj33u4Dd3E/azndD5rd1AQL01g1pAQEEEECghsCiOxfbtBlz7KjJ59teB0/qkd79kX/1dbOvudkeeHhJjRY6u2v5ytX27PPLTHkjI2nmnEbab+ZYGR969BmmpOtSbxuay7wFi0znLHny6XpPi/U4XY9Jp842Jc2r3s40F81DSdv1nsdxCDQowOEIVAS0Pq7AfPNKuvaYWzEv5XrNUn1l4my0JECA3hIfJyOAAAIIhAUUbB96zJl27uz5ds/iB623wG7FqjW+7saFd/lgSwFXkgKny90bB+PcPH7XwJsHCh51juYedulkeYV7s2HpCy+ZksbW2zWpNcZrFyzy11LXqVZ9u/fpb0p/Y0o77rBtQ91r7kFq6EQORiAxAgwkTQJFtzSuINxlbqW8aOG86HZkqt74iUKAAD0KRdpAAAEEEPACCpoUaC91K89+h3sZNWKYHbDPGBt/2FifDhn7Tl8es/vOpjor/wTnJilI19AUdCuvJykQ1nFBru0kJt3ZUI+zAmBdN83h/gbeqNDxcSX9naht/e0c4f6mtF1Pqp6L2mjkutbTPscgkAkBJhGpQGXl3LVadKnyGXS3XSr78Ny6KmVzgbxVldNV76bBbwQCBOgRINIEAggggEBJ4By3al7aMjtp0ni765Yr7Dc/uc4WXDXdZk2f7NPcS0725dvmz6zUKYDXeUtdYK9bqrWdxhQEfQoA6wmA2z1HvTmiwFbOk06d7W/h728MH3RvqOgYnZOEIP3+hx7TcOyDB+1nW44c7rfrfQnmouN/l5A3HDQWEgJ5EcjdPIPPmruJKyB3C+Y+AHfFUp61ek2M1LIAAXrLhDSAAAIIICCBx5582hTEaVsB+RQXoGvVUuW+koJzHZ+0ldpgzLq1O7gtWrk+96w3EXpLwXkKgBWoB+Uk5HvsvrNdevaJfii6Vhpjf28k7L/PGH980l56+9vSmyR67oGStqvHHbxBoX3hOu0jIYBAqgUSN3itfysw73LhuPJKuagt83u1Pyv1ibsAKR0QAXpKLxzDRgABBJImUH1bt4LuRscX3K6swLHRc+M8Xp/X1oPFgqSAXZ/LrpX0+ehgLJqHAuCkBYIKUqdPPdYPMxhjX0F6o6vUvuE2vIzu5fPnul7VKTyUUQ2uuofPp4wAAnkVaHzeRbdkXgrF9bR2bZVyt7scnJfLbodqK8f7lXXtSVd940KcUUuAAL2WCvsQQAABBJoWGL39Nk2fm8UTq9+4SMr8Jk4Y5z+CoPH0F6Qn7S4AjVlJQbjycFq5cnV4V7dyEq9HtwFSQACBzAiUVsZLQbaC76Bc+sx5wYKyQvGiC9KDclrrM3PhOjwRAvQOXwC6RwABBLImoCeFN/NZ5erV5ySZKJjVZ+l7S7/+8Tx79N4FvabebsXu9Bz1EQQ9J0DjCIL0WsH4zxc/qEN8SsLq845v3M6PReOqdXdC9d/evAWL/LHBi+anbw8IyuQIIIBA3AKl4Lt0O7v6UjmcF92OWvvd7vJKe+vnt6t9jZnUmgABemt+nI0AAgggUBZbNEz3AAAQAElEQVQ4cJ8xlaey67PaCobKVf1mum1cSQc2c3u8zosr6WnzCrJ7S0m9Bbwej1pBum7L17XQLf26jtpWW3LQZ9i13ckUPOhNbyocH3rQnca66Ke/rAxPf4N6Yr3e/NF8gocY6kF5utW/ciAbCCCAQAwCPvAuWHml3Fyw7VI2y35uMRDmskkC9FxediaNAAIIxCPwmU98yDes4EmBnpKCPK1kKkAKkgIp7VPdocecaXrwmj/RvQSrum6T3zYIKEgPPpOu7hTU6nro2uh6aZ9SUq6L7mgIPn+u29yP+tx5dujRZ/ikcWuFXMG3HjyocSs4V5Cu+ejvUvsO2HePhp8Ar/NICCCAQCMCPkDXixVcAFtawy5muNyITWPH5utoAvR8XW9miwACCMQqoGBPAVTQiYI9BXl6oJoCpCApkNI+1QVBk4IufRVbUlbQNQ49WV55MJ+s5rpmCmhrzVXXRcG5gt6kzF9j1bg0HgXk+liFksrarzccNBeNW/uqk+4E0N9Z9T62EUAAgTgE/GfK3Yq5QvNioVBaSc9wOQ7DtrSZsE4I0BN2QRgOAgggkHYBBUcKoBTc6lbi/uajgCoIEHVOf8e3q15jUSCnW9vb1Wcn+1FAq+umz9pr3kpzLznZ7r7lCtMbL50cW7hvXZPb5s/049K4g6RrpjmoXudo3Crrb1LBuuaj85r5WII+7667PoKksvogIYAAAn0JFN2SuRbNles45Vkua46k7gKNlgjQGxXjeAQQQCDlAvpKLa1g6/bzd3/kX22vgyf1SLplWKvduhW9mUBEAZMCvN/85DpTwHf9VdOtVtID1hQAKoAKgqqU8zY0fN1+LWslXZN6T9Y1UaCoOxDURn/nnTX1WH8dPj1hXH+Hmq6DAl2lRlfNNRb93ShpjP12Vj5Af5NBKu/qN1OQraBbAXiQ9Den8VefrL9FvQGkYL3R+VS3o6e/666PIB01+XzTmKuPYRsBBBCoFvCBuFsx909ld3mprJX00mfRS2VzK+tmxQzUV8+d7eYFGgzQm++IMxFAAAEEOiuggEmB07hjzjQF3rr9XLcH1xqVbhdW8KegcdzRZ/jjax1Xzz4FTAfuM8ZqJQVZ9bRRfYw+d6zgVOOv3t/ftuajefd3XDvrdU1kraSxaV719C+32+9cbLqel11zc7+n6HhdB+X9HtzCAZfNvcnk/PNf/r+GPuOteevvUikNQa/uDFn6/DLT59/199gCGacigECGBXzQrSjczdEtpJeCcG10K7uC+9Xu0vGlEzaXXaX73VxObr0bJr8RCCQrQI9gQjSBAAIIIFBb4OQZc3zwVF2rz+NqVVGrpUpabVQavf02lcMUxCtQV+BV2dnBDQVEWsVsdDzXXn97t4fRdXAKvXbdyLy0eqyGFCg+9uTT2uxoUmCtNxo0iInlhwVqu550xGFjK4c1+sZL5cQ2bsyZdYrpoxn6t6GV9Eb/Fts4VLpCAIEOCnS5qNoH3VY0n4fKWavvIHWmus5VgJ6pK8dkEEAAgQYEFPgFgY+Cct1u/ui9C0yfx9XncnVrsFJwq/Ddt15puv1ctwVrtVBdzXarowrCtJ3mVO8ctLqtY+9/eEnstzIr2FOSq1bF6wn49MaKjlf6nRuj8k4m3d4e9K83e4LtenLdXRHM/+eLH6znlI4eo7sR9G9Hb2ZpILpm8xYs0iYJAQQQ2CxQKJj/zHkvufWyv1jen7b6zRNnqxUBAvRW9LqfSwkBBBBIrEAQnCugUGChgKi/wep2aK3S3vati/2hWi18vJ+VWgVpCi4VrGil258Y04sC6EaaDlZ3dTdAPed9d+Fdpluujz91ts/rOafZYxTw6c2RIEhVwNefn66P3mxRn/p8tPLekq6J2lTSmzW9HdfK/mAMekNH86nVVjAO5eH64G8yaCdcH5T1N6Z5KNV7LYNzo8zlr2umz7erXbmee9k3tUlCAAEEvEAQnJdWyjcH61kt+0nz0rIAAXrLhO1qgH4QQACB5gWefe5Ff3KjK5s6ScFWcMt7f0GxPoOswEnBStzBkwK1Wg+4622f5qKk8/SAPK2Oq9xb6q++t/Oa3S9nBXwKcNXGpFMus/6C9FEjh+vQfpPeoFFQrKQ3T/o9oYUDdnzjdr2erc/ZawwaT/ggzT+8r1ZZJmpDSe216zr11o8ecKg3sjTWRT+7z3TLe3//TnQsCQEEsi9Q9A9+K5opr7q9Patl4ycSAQL0SBgz0AhTQAABBCIWqDfgirjbuppTgKhU18HuoGBl223G+iuzBVef7fvQHQsK0vsa55InnvLHNvISvNnSyDmNHBu8GVTrnOUrVvndvQW7vrLBF5k1eErkh+ujIPqIiN5c0RsICtKjnGPkA6ZBBBBoi4BfQXc9+TwI0jNcdlPjNwIBAvQIEGmifwGOQACBzgpsOWqEH0BfwZ4/oMaLAo3+bjsOTjtw3z1Mt9ErBbdfB3VR5wqG9Dls3RXQTOpvfAq49Dl9JX0VXNTj7609jUt9q94H6afOrvkUfd0JoHod199K+gfHvtO0yuvT8UfqlMhT8CaGxlTroXVaVQ7+jvR3qL+r6kHos/7V5d629bfl5zFpvGn1urfjWt2v8VSn31V9zl/jr67TtuYfPBxPD+7jCe+tXgHORyD9AsXyZ8l97qbjc7+SXjC3rm5ZK7sp8huBAAF6BIg00XEBBoAAAv0IKOjTIbotuJFbnBVE6envCrp0voIj5b0lBZa6TVsp+Gxub8e2uv+DB+1n1Q+4U9+NpMCk1XHEcb7ecNBc9CaE2tfHBQ495kzTtdM11McIps2Yoyqfqp+C7neEXvRGhlZ5ldR2qDqSYvXfhv5mFMQGDSs4v3zuTRb8HWm/PmYQBPKaV3B8f9dF/WgeSnH+jZ187tWm5w8ESR/b0LiV5B/sr841D9Uraa66BV/bJAQQyKdAaeXcBeMKyh1BUPafQa8q+/1V5bTWuynwG4EAAXoEiDSRdQHmh0D6BRTMaIVPM1Gg8e6P/KspyFDgpyBCQV+QFGRovwIoPSRNt+zqPAVDSbidWGPJQ1Igrdvdg+umVVldO103XavAQKvJemBZUO5Urr8NjVn9a6z6+9GbCBqvbvnW57NVpzceNCcdM2Hy+aZnBmheqlPSar/yTicF2J0eA/0jgEC6BYq6rd3KX7FWlYc/gx4+Lq316b5ayRk9AXpyrgUjyasA80agDQIKnrTaHKzIKvhQkKfgXMG4gqggKVjS/mBFU8NTcB7n7cTqg9RTQKvJuhshCHzDR+i66M2X8P5Olc+aeqxpzEH/ug1ff2cKxrVv/IfeZ5rL2e644G9R+4OkNxu0Qh6UO5nrqwiV9IaCUrWz/i1oX3XSseFUfU4n50LfCCDQGQG3cO7CcrOauYL3oqtzQ8tKvZsKvxEIEKBHgEgTCCRZgLEhEAgocLrr1itNQUO9QZBujVbQoYAkaKfTuQK8u265whQcxT0WfbZYSbf6x91Xb+3rzRXN9dc/nufnrG292SKDJF0XjV8r+fp70d9YdQCuFXMF37POPlGHmf6u9PV9upZB0px0nj8gAS/62jelYHwaczAsbQf7g1zHhpOuXXAOOQII5E+gtDLugnAF4276WS+7KfIbgQABegSINIFAjgWYesoEFEApUNKqrAK+hfNnmgKqcNJ+PRxNQZOCjnqnqUB23oJF/rPS2q73vEaPa0fgozsIgs8X646C8Bj1uepgrr3ltc6rbkeBngLtOZecXL275rauXRAM6rxGDHQtgjsktKJds4OIdmqc+hv7zU+uM/0NKekhe+HgW+PXmw1B0pzqGYLcg7n051tPe/Ueo3npCfhKGnu953EcAgjkV6Do189dgO6WyN1iuSuV9lQ+c+72SKe67I+rOj5N9RorqXUBAvTWDWkBAQRiE6DhOAUUcOyx+86mADyctL+ZvhU4XesCdKXgtubqdhQcTjp1tvWVFOxWn9OpbY016LvWQ9j0RHLNs6+kjw8EbdTKdQ0U7CmvVR/VPs0lSLXa1MPaDj36DOsr6XPktc5t97477lxswVwUrIf71z6Nta+5qE7Hhc/tq6zrdPetV5pSX8dRhwACCAQCRStYlwvCSyvnCs4LKll1OUv1wbzJWxMgQG/Nj7MRQCDNAow9coElTzzl29Qt9Eq+EHrRynRfSbeUh07pSDF4OJ7mUesNCwVsHRlYE50Gc9Gt5lqFDzehNwiWvvCS9ZWCNsLntrscjEO30Osz+OH+NRcd09dcVKc3WMLnUkYAAQSiFFBIriC96BotumA962U3TX4jECBAjwCRJhBAAIFaAnnbp9uo9fA5zfszE8Yp65EUIAY7FWDpduEgqRzUJSFfvmKVH4buLvAbNV6CMSvo1a3qQUraZ8ODN06OPGxsjVmYVb/ZoGukNyWCpHLNkzq0U8G3utbX7CkY13Y46W9K+zT2YB7KVdZ+EgIIINAOgaLrpBSUm+Uhd9PlNwIBAvQIEGkCAQQQ6IBA4rpUgB4M6m277xxs9prPmXWKv11YtwwrjXnLLr0e24kKrbKq376CulEjh+sQH+AqyA1SsN9XJuClnrkEw1QQv+Cq6RYklYO6JOTPPveiH4as/UYfL3pzJZiHcj09vo/DqUIAAQQiFQhuX/e5a9kH6QUr3fbuyn5/VTnt9W5KDf3qvxs+PXWWTZx2qW3ctKmhc2sd/Mvf/t5OOuequtIjS/5aq4lE7CNAT8RlYBAIIIBA0gRaG089wVP4mHC5tRFEd3Zft0IHgW90vcXbUl9vNgQ9h48Jl4PjOpUHb37UM67g2GCsI8tvqARlcgQQQCBuga6i1tGrgvKqsvrOUr3m00j63qKf20N/eMIefORPVuwqOTVyfvhYBfz3/uphqye99PJr4dMTUyZAT8ylYCAIIIBAdgT00LFas1n6/LLS7hS9BrdUh4es/xAI9oWDxd5uvQ6O71T++JNP1+y6ei41D0jgzt6ui4YavHGS1OugMZIQQCD7Aloht/IKeR7y/q7omrXr7T/u+pV986Yf+1Xz62/5aX+nNF3/8cPfb3pOSW9ppzdu13TbcZ9IgB63MO0jgAACORSoJxAMr25GyRRFW/rMstrRE8P1UDttV6d5199eKYZv6U/aSm3wBkJvD+Crnl9S72QIsLccNcJv/nzxgz4Pv1TPJZh3+BjKCCCAQDsE9LR2rZDnJe/P9NXlK236pf9uV31zoV817+/4VupP/8InTM+D6S3t/g87ttJ8rOcSoMfKS+MIIIBAfgT0ed8gINJXj1UHSlK4xwVUN/7gZ9o0PcQr6aubevCbH6x70dfCaU4K1hfdudh/Tdyin93nasw051pPefeVCXnRtdFQdA301W/VXzGm6zR77k2qNj30Lvxmg69I0EtwXXQ3xrQZc6x6LroT4JzZ8yujTfpcKgNlAwEEMimQp+Bcb0L0dxH1v/vTTvi4BSl4I7y/8/JWT4CetyvOfBFAAIEYBYIHiil4UlCrpO9GVyClFDzlffyH+0dKjwAAEABJREFUD+oxiqStqCsQPGnS+Mo45y1YZJqLkoLaoKL6mGBfa3n0Z09x89AbCWr5xoV32bijz7BDy0nXKLguEz/xIdN/QOm4IIXLwf5O5YeMfad/U0T96w2H6rmMO+ZM09+e6vQffuE3TpL2N6ZxkhBAIMMC5dvbFbwqWA9uc89suZ9LOWL4UPviZz5WSQe9a+9+zshnNQF6Pq87s0YAAQRiEVAgWB2wKpDVqrMCqaDDMbvv7D8XFpSDPGmBoMal+ej2OK0sq1ydFPDOmj7ZFMhX70/itm5bX3DVdL9Cbm6ACsj1OW0lV/S/mo8+q+cLVS9Ju10/mIvGq2H2NhddG9VXpyT+jVWPj20EEMiWgIJyPfqsWCxaEJQHZR+sa7+bclbq3VQS8/vqayvthRdfsdeWrzL5JmZgdQyEAL0OJA5BAAEEEKhfQEGtgiOtYFafpSBXAeCcS07usUrb7biRpa8uq97XyW2N+a5br7S5btwK1pWud8HubfNn9hqc600IHaPUybFX963AVvPQ9dFHDII6jVVvqmg+vQWwOl7HBef0lbejTnPReGvNRW+Y6M0IHRMei1bQg7loO1xPGQEEEIhSQEF50dz/uZV092rVZT1Arrqchfoo7Vpt66OfOdsO+cRp9t6PnWRv/8Dxdvinz7Kbfni39fXNLK32GdX5BOhRSdIOAggggEBFIAiSfv3jebbQBbJKv/nJdf6BLbUCJ52oYOvRexf4QFjlJCUFrrq1WsG6kj7TrX29jVF1Okapt2M6sV/jUjCu752XtVIQ6Kqu1pg0Bx2v42rVt3lfpTuNt9Zc9OZQb39jOieYi7YrjbGBAAIIxCDgg3DXbikvWikPvnIte2U31cT+PvXMC3bpnJvs6C9e5FfVEztQNzACdIfALwIIIIBAPAIKgvQ5YKV4eqBVBKIUoC0EEEAgOgHdzt49KA+C82zm0ck119Lee7zZZn7pBLthzjn2owWz7Kc3fcW+N+88O/eUiRZ8rZoC9VPOn9tcB206iwC9TdB0gwACCCCAAAI5F2D6CCCQK4Giuf8ruOTzgl6tWCmb+ZpKOf31nb64e751VzvqI++3/fZ+q+226462845vsL333M2OPfKDdvu3L7a3vnknP0Q9H2fZy6/57SS+EKAn8aowJgQQQAABBBBAoEEBDkcAgWQJaAVdDyjznzUvai3dBeXVD4Zzw81SvZtOYn+HDxtqk47+cGV8jz3xdGU7aRsE6Em7IowHAQQQQAABBBBIngAjQgCBBgUUkis4909zL1jpM+i1cgXttfZrjV37U1LfIE/bD99+u60qfb762orKdtI2CNCTdkUYDwIIIIAAAgggkDsBJoxA9gR8cO6D7KL1CNK7Bd3ZqE/6FXz62b9XhrjzTttXtpO2QYCetCvCeBBAAAEEEEAAAQSiFaA1BDog4INy129X0cwH6wrKfbkYKmej3k0ttt+XXlluF3/9Bp/mfvuHPfpZvnK16bPlPSrKO9asXW/fuvkn5ZLZ7rvuWNlO2gYBetKuCONBAAEEEEAAAQQQSJUAg0WgpkCh6G9rN92mbi5Kz3q5JkL3natWr7UgrVu3vlIZ7FO+YcPGyv5gY/mKVXbLHff49P0f/SLYXcmf//vLNunU2TbhxAvsjp/dZ4//+f9srWt/9Zp19psH/2jHTplpzzz3oj9+ymePsBHDh/rtJL4QoCfxqjAmBBBAAAEEEEAAAQRKArymVKCrPO6uYmmr9GqW1XJ5ur1mz7/4sh14+Bcr6doFiyrHvu+IqZX9X//3H1T2N7rx2BNP2TmXfdM+/rnzbL8Pfd4O+PAX7HOnf8X+9JdnfFN6qvvk4z7qt5P6QoCe1CvDuBBAAAEEEEAAAQQQiF2ADuIScGvmfgXd397uVtCzXu7PsaBbCfo7yNUXCgX32v13wIDNYevgwYO6V7qSHgD3uU8dbspdscevnuI+feqxduPcc2yLIYN71Cdpx+aZJmlUjAUBBBBAAAEEEEAAAQTSL5DjGXT58NytmCs4dzFn1sv9XWoFz4/eu8D6S1+ackyPpnbZafvKeff84Os96l83aoSd/oVP2s+//zX7xcKr7Pv/dqFde+mpNv+KL9l/uX33/+d1NnHCOBs0cGCPc5O2gwA9aVeE8SCAAAIIIIAAAggggEBdAkk+KFgx1xi7iiqVgvWgrD1dLngPyj6vKqexXnPoZCoUCvaGbV9ve71tVzv4vfvYe/bfy974hq2tUHDvkFg6fgjQ03GdGCUCCCCAAAIIIIAAAgi0V6Cl3ooKtl1cqCA8uM3dqspZq28Ji5MrAgToFQo2EEAAAQQQQAABBBBAAIH/z97dw8pSlnEAn1v62UgiwYSKAjqDsbs2kiidFNpJgq3GaGmilY00NiZYURCojJjQqRhouJVEQuctrExQEmnED7pzmHfO2WXPufs1u+/MvO/z/m7Ont3ZmXnneX7Pbf7ZPbt5BIZQ3r9ynl4Jv0z3KZxf39/Y7i93Y7s/7sZ2Jfv7Mv1kEBDQMyBaggABAgQIECBAgAABApsC6W3tQ0jvX0kf7q/D+cXt+yD7N3v3+HQBAf10O2cSIECAAAECBAgQIEBgq8AQylfhe8b7pa67FcGTowUE9NFkTiBAgAABAgQIECBAgMB+gfQ35uu3t/eHpu3+rhvevt4/SNsV7t9Zf9+SnwwCAnoGREsQIECAAAECBAgQIEBgU2AI39evnK/C+OYHxkXbv9n76Y+dKaD7P0CAAAECBAgQIECAAIHMAkMY79fcdt8/PXxLegrpUfannoq/VVCggF7BkJRIgAABAgQIECBAgEBdArvCd9Tn65rONNXmWFVAz6FoDQIECBAgQIAAAQIECGwIDG9rv9NdvVLe30ff3mjdwzME9gT0M1Z1KgECBAgQIECAAAECBBoWSJ+mnj4QLhGsvnIt8nbq0+18geUC+vm1W4EAAQIECBAgQIAAAQJFCqxCefob865/BT36dpFDqLCosAG9wlkomQABAgQIECBAgACBIALpFfR1KL+87G5sd7e2A+wPMrbF2xDQTxuBswgQIECAAAECBAgQILBTYGc4T2G8D+jR9u+EsGOUgIA+imuug12HAAECBAgQIECAAIGqBdLb2vsgPry9vbvoru6vXzlfP395/XyA/Z1/OQQE9ByKta2hXgIECBAgQIAAAQIEJhUY/va8D+JX93f6iN6H8X67j+j9dT/ZjrK/b8pPBgEBPQOiJW4K2CJAgAABAgQIECDQukCK4yl8b79Pe66/gq2HSls3j0vP1LW/b8NPBgEBPQOiJWYVcDECBAgQIECAAAECxQukiH155+qV8vSq+c3t6/AdaH/xA6mkQAG9kkEpcy4B1yFAgAABAgQIECCQR+DiMsXyqzCeVoy+nXp0O09AQD/Pz9kExgk4mgABAgQIECBAoAmBFM0v73RXf3Xe30ffbmKoMzQpoM+A7BIE5hJwHQIE6hX48L//7177w73uzXvvdH/9298PNrI6Pp1z/4jjDy7oAAIECBDIKjCE8/SVan04v2zgPitew4sJ6A0PX+sERgo4nACBCQXee/+D7qfPv9j98Ge/6r73o190aXvf5V559fXh+HROCun7jrWPAAECBOYXuLgO5Rfpbe59SL8Ivj2/cMwrCugx56orAhUKKJlA2wJPPPZo98jDDw0I//nfR8Or6cPGjl+v/PaP6z1P3X1y/dgDAgQIEChDIL2Cvnpb+wP3q7Ce3gCfwvvt+wr3l6FefxUCev0z1AEBAscIOIZABQI/eO6ZdZX7XhV/+937XQrx6eCvfvnxLt3SYzcCBAgQKEfgIr1y3peTPsE9fYXa5Wp7Fb5X2ymcp+NW25Xu71vwk0FAQM+AaAkCBAgQIJBDYDNo/+P9D4a/R9+27gsvvbZ+ejPUr5/0gAABAgSWF1i9Mt5XMoT0fnvzvuu3h1fWg+zv2/CTQUBAz4BoCQIECEwsYPlGBL708EPdM0/fXXf78quvrx+vHqRXz9MtbX/uM5/y6nmCcCNAgECBAv/+6Cfdh/0t3e+6Rdpf4AiqLElAr3JsiiZAgEBOAWuVJPD9jbe5pyB++8Pi3rj3zrrcZ7/zzfVjDwgQIECAAIH6BQT0+meoAwIECJQtoLpRAulV9M23uv964+3sw1er/f6tYb306vmz3/7G8NgvAgQIECBAIIaAgB5jjrogQIBAswIRG998m/uf372/bjF9tdrqw+Ge+tpXus9/9tPrfR4QIECAAAEC9QsI6PXPUAcECBAgMJ3AIiungL76yrX0YXGrT3Tf/Gq1dMwixbkoAQIECBAgMJmAgD4ZrYUJECBAgMAhgd37Nz+dPQX09Pfoq1fP01vg02332fYQIECAAAECNQoI6DVOTc0ECBAgEF5gM4CncP7cj59f93z0q+frMzwgQIAAAQIEahAQ0GuYkhoJECBAoDmB9GFx24J4+nC4r999sggPRRAgQIAAAQJ5BQT0vJ5WI0CAAAEC2QS+u+VT2tNXqzXy4XDZHC1EgAABAgRqERDQa5mUOgkQIECgOYEnHnu023yrewLw1WpJIcfNGgQIECBAoDwBAb28maiIAAECBAisBdJb3VcbKax79XylUfi98ggQIECAwAkCAvoJaE4hQIAAAQJzCbzx1l/Wl9r8ZPf1kx40KaBpAgQIEIgpIKDHnKuuCBAgQCCAwJv33ul8tVqAQdbXgooJECBAYCEBAX0heJclQIAAAQKHBF5+9fX1IU/55Pa1hQe1C6ifAAECBHYJCOi7ZDxPgAABAgQWFHj73ftduqUS0lerfevpu+mhGwEChwTsJ0CAQMUCAnrFw1M6AQIECMQVeOGl19bN+Wq1NYUHBBYXUAABAgSmFBDQp9S1NgECBAgQOFHgvX/+q3vki1/oHn/s0c5Xq52I6DQC9QmomACBxgUE9Mb/A2ifAAECBMoU+NNvftml2+9e/Hnnq9XKnJGqCNQnoGICBEoXENBLn5D6CBAgQIAAAQIECNQgoEYCBM4WENDPJrQAAQIECBAgQIAAAQJTC1ifQAsCAnoLU9YjAQIECBAgQIAAAQL7BOwjUISAgF7EGBRBgAABAgQIECBAgEBcAZ0ROE5AQD/OyVEECBAgQIAAAQIECBAoU0BVYQQE9DCj1AgBAgQIECBAgAABAgTyC1hxPgEBfT5rVyJAgAABAgQIECBAgACBmwK2NgQE9A0MDwkQIECAAAECBAgQIEAgkkBdvQjodc1LtQQIECBAgAABAgQIECBQikDmOgT0zKCWI0CAAAECBAgQIECAAAECpwjcDuinrOEcAgQIECBAgAABAgQIECBA4EyBmQP6mdU6nQABAgQIECBAgAABAgQIBBWIFdCDDklbBAgQIECAAAECBAgQIBBfQEAfMWOHEiBAgAABAgQIECBAgACBqQQE9Klkx6/rDAIECBAgQIAAAQIECBBoWEBAb2b4GiVAgAABAgQIECBAgACBkgUE9JKnU1NtaiVAgJ+6AiQAAA1sSURBVAABAgQIECBAgACBswQE9LP4nDyXgOsQIECAAAECBAgQIEAguoCAHn3C+jtGwDEECBAgQIAAAQIECBBYXEBAX3wECogvoEMCBAgQIECAAAECBAgcFhDQDxs5gkDZAqojQIAAAQIECBAgQCCEgIAeYoyaIDCdgJUJECBAgAABAgQIEJhHQECfx9lVCBDYLuBZAgQIECBAgAABAgSuBQT0awh3BAhEFNATAQIECBAgQIAAgXoEBPR6ZqVSAgRKE1APAQIECBAgQIAAgYwCAnpGTEsRIEAgp4C1CBAgQIAAAQIE2hIQ0Nuat24JECCwEnBPgAABAgQIECBQmICAXthAlEOAAIEYArogQIAAAQIECBAYKyCgjxVzPAECBAgsL6ACAgQIECBAgEBAAQE94FC1RIAAAQLnCTibAAECBAgQILCEgIC+hLprEiBAgEDLAnonQIAAAQIECGwVENC3sniSAAECBAjUKqBuAgQIECBAoFYBAb3WyambAAECBAgsIeCaBAgQIECAwGQCAvpktBYmQIAAAQIExgo4ngABAgQItCwgoLc8fb0TIECAAIG2BHRLgAABAgSKFhDQix6P4ggQIECAAIF6BFRKgAABAgTOExDQz/NzNgECBAgQIEBgHgFXIUCAAIHwAgJ6+BFrkAABAgQIECBwWMARBAgQILC8gIC+/AxUQIAAAQIECBCILqA/AgQIEDhCQEA/AskhBAgQIECAAAECJQuojQABAjEEBPQYc9QFAQIECBAgQIDAVALWJUCAwEwCAvpM0C5DgAABAgQIECBAYJuA5wgQILASENBXEu4JECBAgAABAgQIxBPQEQECFQkI6BUNS6kECBAgQIAAAQIEyhJQDQECOQUE9Jya1iJAgAABAgQIECBAIJ+AlQg0JiCgNzZw7RIgQIAAAQIECBAgcCXgN4HSBAT00iaiHgIECBAgQIAAAQIEIgjogcBoAQF9NJkTCBAgQIAAAQIECBAgsLSA60cUENAjTlVPBAgQIECAAAECBAgQOEfAuYsICOiLsLsoAQIECBAgQIAAAQIE2hXQ+XYBAX27i2cJECBAgAABAgQIECBAoE6BaqsW0KsdncIJECBAgAABAgQIECBAYH6B6a4ooE9na2UCBAgQIECAAAECBAgQIHC0wBDQjz7agQQIECBAgAABAgQIECBAgMAkAnME9EkKtygBAgQIECBAgAABAgQIEIgkECCgRxqHXggQIECAAAECBAgQIECgVQEB/dDk7SdAgAABAgQIECBAgAABAjMICOgzIO+7hH0ECBAgQIAAAQIECBAgQCAJCOhJIe5NZwQIECBAgAABAgQIECBQiYCAXsmgyixTVQQIECBAgAABAgQIECCQS0BAzyVpnfwCViRAgAABAgQIECBAgEBDAgJ6Q8PW6k0BWwQIECBAgAABAgQIEChJQEAvaRpqiSSgFwIECBAgQIAAAQIECIwSENBHcTmYQCkC6iBAgAABAgQIECBAIJqAgB5tovohkEPAGgQIECBAgAABAgQIzC4goM9O7oIECBAgQIAAAQIECBAgQOBBAQH9QRPPECBQt4DqCRAgQIAAAQIECFQpIKBXOTZFEyCwnIArEyBAgAABAgQIEJhGQECfxtWqBAgQOE3AWQQIECBAgAABAs0KCOjNjl7jBAi0KKBnAgQIECBAgACBcgUE9HJnozICBAjUJqBeAgQIECBAgACBMwQE9DPwnEqAAAECcwq4FgECBAgQIEAgtoCAHnu+uiNAgACBYwUcR4AAAQIECBBYWEBAX3gALk+AAAECbQjokgABAgQIECBwSEBAPyRkPwECBAgQKF9AhQQIECBAgEAAAQE9wBC1QIAAAQIEphWwOgECBAgQIDCHgIA+h7JrECBAgAABArsF7CFAgAABAgQGAQF9YPCLAAECBAgQiCqgLwIECBAgUIuAgF7LpNRJgAABAgQIlCigJgIECBAgkE1AQM9GaSECBAgQIECAQG4B6xEgQIBASwICekvT1isBAgQIECBAYFPAYwIECBAoSkBAL2ociiFAgAABAgQIxBHQCQECBAiMExDQx3k5mgABAgQIECBAoAwBVRAgQCCcgIAebqQaIkCAAAECBAgQOF/ACgQIEJhfQECf39wVCRAgQIAAAQIEWhfQPwECBLYICOhbUDxFgAABAgQIECBAoGYBtRMgUKeAgF7n3FRNgAABAgQIECBAYCkB1yVAYCIBAX0iWMsSIECAAAECBAgQIHCKgHMItCsgoLc7e50TIECAAAECBAgQaE9AxwQKFhDQCx6O0ggQIECAAAECBAgQqEtAtQTOERDQz9FzLgECBAgQIECAAAECBOYTcKXgAgJ68AFrjwABAgQIECBAgAABAscJOGppAQF96Qm4PgECBAgQIECAAAECBFoQ0ONBAQH9IJEDCBAgQIAAAQIECBAgQKB0gQj1CegRpqgHAgQIECBAgAABAgQIEJhSYJa1BfRZmF2EAAECBAgQIECAAAECBAjsErh6XkC/cvCbAAECBAgQIECAAAECBAgsKjBZQF+0KxcnQIAAAQIECBAgQIAAAQKVCdQa0CtjVi4BAgQIECBAgAABAgQIENgvIKBv9fEkAQIECBAgQIAAAQIECBCYV0BAn9f76mp+EyBAgAABAgQIECBAgACBWwIC+i2QCJt6IECAAAECBAgQIECAAIH6BAT0+ma2dMWuT4AAAQIECBAgQIAAAQITCAjoE6Ba8hwB5xIgQIAAAQIECBAgQKBNAQG9zbm327XOCRAgQIAAAQIECBAgUKiAgF7oYJRVp4CqCRAgQIAAAQIECBAgcKqAgH6qnPMIzC/gigQIECBAgAABAgQIBBYQ0AMPV2sExgk4mgABAgQIECBAgACBJQUE9CX1XZtASwJ6JUCAAAECBAgQIEBgr4CAvpfHTgIEahFQJwECBAgQIECAAIHaBQT02ieofgIE5hBwDQIECBAgQIAAAQKTCwjokxO7AAECBA4J2E+AAAECBAgQIECg6wR0/wsIECAQXUB/BAgQIECAAAECVQgI6FWMSZEECBAoV0BlBAgQIECAAAECeQQE9DyOViFAgACBaQSsSoAAAQIECBBoRkBAb2bUGiVAgACBBwU8Q4AAAQIECBAoR0BAL2cWKiFAgACBaAL6IUCAAAECBAiMEBDQR2A5lAABAgQIlCSgFgIECBAgQCCWgIAea566IUCAAAECuQSsQ4AAAQIECMwsIKDPDO5yBAgQIECAQBJwI0CAAAECBG4LCOi3RWwTIECAAAEC9QvogAABAgQIVCggoFc4NCUTIECAAAECywq4OgECBAgQmEJAQJ9C1ZoECBAgQIAAgdMFnEmAAAECjQoI6I0OXtsECBAgQIBAqwL6JkCAAIFSBQT0UiejLgIECBAgQIBAjQJqJkCAAIGTBQT0k+mcSIAAAQIECBAgMLeA6xEgQCCygIAeebp6I0CAAAECBAgQGCPgWAIECCwqIKAvyu/iBAgQIECAAAEC7QjolAABAvsFBPT9PvYSIECAAAECBAgQqENAlQQIVC8goFc/Qg0QIECAAAECBAgQmF7AFQgQmF5AQJ/e2BUIECBAgAABAgQIENgvYC8BAr2AgN4j+CFAgAABAgQIECBAILKA3gjUISCg1zEnVRIgQIAAAQIECBAgUKqAughkEhDQM0FahgABAgQIECBAgAABAlMIWLMdAQG9nVnrlAABAgQIECBAgAABArcFbBckIKAXNAylECBAgAABAgQIECBAIJaAbsYICOhjtBxLgAABAgQIECBAgAABAuUIBKtEQA82UO0QIECAAAECBAgQIECAQB6BuVcR0OcWdz0CBAgQIECAAAECBAgQINB1DxgI6A+QeIIAAQIECBAgQIAAAQIECMwvkDegz1+/KxIgQIAAAQIECBAgQIAAgRACVQX0EOKaIECAAAECBAgQIECAAAECWwQE9E9QPCJAgAABAgQIECBAgAABAosJCOiz0bsQAQIECBAgQIAAAQIECBDYLSCg77apa49qCRAgQIAAAQIECBAgQKBqAQG96vHNV7wrESBAgAABAgQIECBAgMC0AgL6tL5WP07AUQQIECBAgAABAgQIEGheQEBv/r9ACwB6JECAAAECBAgQIECAQPkCAnr5M1Jh6QLqI0CAAAECBAgQIECAQAYBAT0DoiUITClgbQIECBAgQIAAAQIE2hAQ0NuYsy4J7BLwPAECBAgQIECAAAEChQgI6IUMQhkEYgroigABAgQIECBAgACBYwUE9GOlHEeAQHkCKiJAgAABAgQIECAQSEBADzRMrRAgkFfAagQIECBAgAABAgTmFBDQ59R2LQIECHwi4BEBAgQIECBAgACBGwIC+g0OGwQIEIgioA8CBAgQIECAAIHaBAT02iamXgIECJQgoAYCBAgQIECAAIHsAgJ6dlILEiBAgMC5As4nQIAAAQIECLQoIKC3OHU9EyBAoG0B3RMgQIAAAQIEihQQ0Isci6IIECBAoF4BlRMgQIAAAQIEThMQ0E9zcxYBAgQIEFhGwFUJECBAgACBsAICetjRaowAAQIECIwXcAYBAgQIECCwnMDHAAAA//+ulRQIAAAABklEQVQDAECj/cIiMOwGAAAAAElFTkSuQmCC"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "displaced = bulk(\"Al\", cubic=True)\n",
+    "displaced.positions[0] += [0.4, 0.0, 0.0]\n",
+    "\n",
+    "centro = stk.analyse.get_centro_symmetry_descriptors(structure=displaced, num_neighbors=12)\n",
+    "fig = stk.visualize.plot3d(displaced, mode=\"plotly\", scalar_field=centro)\n",
+    "fig.show(renderer=\"png\", width=500, height=400, scale=2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "291003d3",
+   "metadata": {},
+   "source": [
+    "## Where to go from here\n",
+    "\n",
+    "* Browse the [source code](https://github.com/pyiron/structuretoolkit/tree/main/src/structuretoolkit) &ndash;\n",
+    "  every function has a docstring with the full list of arguments.\n",
+    "* Have a look at the [test suite](https://github.com/pyiron/structuretoolkit/tree/main/tests), which\n",
+    "  contains many more focused, runnable usage examples for each function shown here.\n",
+    "* `structuretoolkit` is also used as the structure-analysis backend of\n",
+    "  [`pyiron_atomistics`](https://github.com/pyiron/pyiron_atomistics), where the same functions are\n",
+    "  available as methods directly on the structure object (e.g. `structure.analyse.get_neighbors()`).\n",
+    "* If a function is missing optional dependencies (`pyscal3`, `spglib`, `aimsgb`, `dscribe`, `mp-api`,\n",
+    "  `nglview`, ...), install the corresponding extra, e.g. `pip install structuretoolkit[pyscal,symmetry]`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/structuretoolkit/analyse/snap.py
+++ b/src/structuretoolkit/analyse/snap.py
@@ -267,13 +267,13 @@ def _set_ase_structure(lmp, structure: Atoms):
     positions = positions.flatten()
     elem_all = np.array([el_dict[el] + 1 for el in structure.get_chemical_symbols()])
     lmp.create_atoms(
-        n=len(structure),
-        atomid=None,
-        atype=(len(elem_all) * c_int)(*elem_all),
-        x=(len(positions) * c_double)(*positions),
-        v=None,
-        image=None,
-        shrinkexceed=False,
+        len(structure),
+        None,
+        (len(elem_all) * c_int)(*elem_all),
+        (len(positions) * c_double)(*positions),
+        None,
+        None,
+        False,
     )
 
 


### PR DESCRIPTION
## Summary
- `_set_ase_structure()` in `src/structuretoolkit/analyse/snap.py` called `lmp.create_atoms()` with the keyword arguments `atomid=` and `atype=`.
- The LAMMPS python module has renamed these parameters across releases: `id`/`type` in builds through stable_29Aug2024 (the version on conda-forge), and `atomid`/`atype` starting with stable_22Jul2025 and the current dev branch.
- Calling with `atomid=`/`atype=` against an `id`/`type`-named install raises `TypeError: lammps.create_atoms() got an unexpected keyword argument 'atomid'`, breaking `get_snap_descriptors_per_atom()` and `get_snap_descriptor_derivatives()`.
- Fixed by calling `create_atoms()` positionally, which works regardless of which keyword spelling a given LAMMPS release uses.

## Test plan
- `tests/test_snap.py`'s `TestSNAP` class already exercises the public `get_snap_descriptors_per_atom()` / `get_snap_descriptor_derivatives()` API under the `skip_snap_test` guard (skipped if `lammps` isn't importable).
- CI (`pipeline.yml`) merges in a LAMMPS conda environment before running the test suite, so this existing test acts as the regression test for this fix.
- [ ] Confirm `TestSNAP` passes in CI with the LAMMPS environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)