### PR TITLE
Add lint rule PLR0917 to ignore argument count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ ignore = [
     "PLC0415",
     # Too many arguments in function definition
     "PLR0913",
+    # Too many not-keyword-only arguments,
+    "PLR0917",
     # Magic value used in comparison
     "PLR2004",
     # Too many branches


### PR DESCRIPTION
Added a new linting rule to ignore too many not-keyword-only arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to allow functions with multiple positional arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->